### PR TITLE
C Block support for functions that normally come in begin/end pairs.

### DIFF
--- a/Gosu/Graphics.hpp
+++ b/Gosu/Graphics.hpp
@@ -29,6 +29,10 @@ namespace Gosu
     Transform scale(double factor);
     Transform scale(double factorX, double factorY, double fromX = 0, double fromY = 0);
     
+#ifdef __BLOCKS__
+    typedef void (^GraphicsBlock)(void);
+#endif
+    
     //! Serves as the target of all drawing and provides primitive drawing
     //! functionality.
     //! Usually created internally by Gosu::Window.
@@ -110,6 +114,22 @@ namespace Gosu
         std::auto_ptr<ImageData> createImage(const Bitmap& src,
             unsigned srcX, unsigned srcY, unsigned srcWidth, unsigned srcHeight,
             unsigned borderFlags);
+
+#ifdef __BLOCKS__
+        //! Executes the block in a clean OpenGL environment, resetting Gosu
+        //! to its default rendering state after the block returns.
+        void gl(GraphicsBlock block);
+        
+        //! Executes the block with all drawing clipped to a specified rectangle.
+        void clipTo(double x, double y, double width, double height, GraphicsBlock block);
+        
+        //! Executes the block, applying a specified transformation to all
+        //! drawing operations.
+        void transform(const Transform& transform, GraphicsBlock block);
+        
+        //! Records the block as a macro, returning the result as a drawable object.
+        std::auto_ptr<Gosu::ImageData> record(GraphicsBlock block);
+#endif
     };
 }
 

--- a/GosuImpl/Graphics/Graphics.cpp
+++ b/GosuImpl/Graphics/Graphics.cpp
@@ -483,7 +483,7 @@ void Gosu::Graphics::gl(GraphicsBlock block)
     endGL();
 }
 
-void Gosu::Graphics::clip(double x, double y, double width, double height, GraphicsBlock block)
+void Gosu::Graphics::clipTo(double x, double y, double width, double height, GraphicsBlock block)
 {
     beginClipping(x, y, width, height);
     block();

--- a/GosuImpl/Graphics/Graphics.cpp
+++ b/GosuImpl/Graphics/Graphics.cpp
@@ -473,3 +473,35 @@ std::auto_ptr<Gosu::ImageData> Gosu::Graphics::createImage(
 
     return data;
 }
+
+#ifdef __BLOCKS__
+
+void Gosu::Graphics::gl(GraphicsBlock block)
+{
+    beginGL();
+    block();
+    endGL();
+}
+
+void Gosu::Graphics::clip(double x, double y, double width, double height, GraphicsBlock block)
+{
+    beginClipping(x, y, width, height);
+    block();
+    endClipping();
+}
+
+void Gosu::Graphics::transform(const Transform& transform, GraphicsBlock block)
+{
+    pushTransform(transform);
+    block();
+    popTransform();
+}
+
+std::auto_ptr<Gosu::ImageData> Gosu::Graphics::record(GraphicsBlock block)
+{
+    beginRecording();
+    block();
+    return endRecording();
+}
+
+#endif


### PR DESCRIPTION
This basically amounts to syntax sugar—makes the C++ interface for these sorts of operations more like the Ruby interface. It only works where blocks are available, of course. Observe.

```
graphics().transform(translate(-scrollX, -scrollY), ^{
    allTheThings.draw();
    player.draw();
});

graphics().gl(^{
    glFantastic3DEffects();
    glDoMagic();
    glApplyTrendyBloomFilter();
});
```

I'm not sure this support is compiled in by default on OS X since Gosu is using the 10.4 SDK, but it would be a nice bonus for people who don't mind compiling Gosu themselves. I'm pretty sure Clang supports Blocks on other platforms, too, so I think they are here to stay.
