### PR TITLE
std::runtime_error requires <stdexcept> on Linux.

### DIFF
--- a/GosuImpl/Graphics/BitmapFreeImage.cpp
+++ b/GosuImpl/Graphics/BitmapFreeImage.cpp
@@ -3,6 +3,7 @@
 #include <Gosu/Platform.hpp>
 #include <Gosu/TR1.hpp>
 #include <Gosu/Utility.hpp>
+#include <stdexcept>
 #include <vector>
 #include <FreeImage.h>
 


### PR DESCRIPTION
Linux machines building Gosu 0.7.36.1 or installing the gem will find an unpleasant surprise:

BitmapFreeImage.cpp: In function ‘void<unnamed>::checkForFreeImageErrors(bool)’:
BitmapFreeImage.cpp:100:19: error: ‘runtime_error’ is not a member of ‘std’
make: **\* [BitmapFreeImage.o] Error 1

This patch fixes the problem by including the required header.

Cheers,
Jamer
