### PR TITLE
X11 Expose event

### DIFF
--- a/GosuImpl/WindowX.cpp
+++ b/GosuImpl/WindowX.cpp
@@ -160,6 +160,13 @@ struct Gosu::Window::Impl
                 else if (event.type == FocusOut)
                     active = false;
             }
+            if (event.type == Expose && event.xexpose.count == 0 &&
+                        window->graphics().begin(Colors::black)) {
+                FPS::registerFrame();
+                window->draw();
+                window->graphics().end();
+                glXSwapBuffers(display, this->window);
+            }
         }
         
         if (showingCursor && !window->needsCursor())


### PR DESCRIPTION
Hurray! It appears that X11 _does_ let you know when you've become uncovered and have to redraw.

Okay, here's the story: I noticed Battle fom Wesnoth redrew itself normally upon being damaged, so I ran through its sources looking for why. It turned out the answer was in the SDL library, which listens for the Expose XEvent.

In this branch, I have replaced the horrible hack that was there before with listening for this new event.

Cheers,
Jamer
