### PR TITLE
more zen, just for fun

### DIFF
--- a/lib/gosu/zen.rb
+++ b/lib/gosu/zen.rb
@@ -1,28 +1,79 @@
-require 'gosu'
-require 'singleton'
+require 'gosu/preview'
 
 module Gosu
-  class ZenWindow < Window
-    include Singleton
+  module Zen
     
-    def initialize
-      super 800, 600, false
+    @@video_mode = [800, 600, {}]
+    @@options = {}
+    
+    def video width, height, options = nil
+      if $window.nil?
+        puts @@video_mode.inspect
+        @@video_mode[0] = width
+        @@video_mode[1] = height
+        @@video_mode[2].merge! options
+      else
+        raise "video mode can only be set before the window is created"
+      end
     end
+    
+    def set what, value
+      if $window.nil?
+        @@options[what.to_sym] = value
+      else
+        $window.send "#{what}=", value
+      end
+    end
+    
+    def button_down id = nil, &body
+      m = id ? "button_down_#{id}" : :button_down_other
+      ZenWindow.send :define_method, m, &body
+    end
+    
+    def button_up id = nil, &body
+      m = id ? "button_up_#{id}" : :button_up_other
+      ZenWindow.send :define_method, m, &body
+    end
+    
+    def update &body
+      ZenWindow.send :define_method, :update, &body
+    end
+    
+    def draw &body
+      ZenWindow.send :define_method, :draw, &body
+    end
+    
+    def run!
+      window = ZenWindow.new *@@video_mode
+      @@options.each do |opt, value|
+        window.send "#{opt}=", value
+      end
+      window.show
+    end
+    
+    def Zen.included mod
+      at_exit &method(:run!)
+    end
+    
   end
-end
-
-def set what, value
-  Gosu::ZenWindow.instance.send "#{what}=", value
-end
-
-def update(&proc)
-  Gosu::ZenWindow.send :define_method, :update, proc
-end
-
-# WIP - needs all other callbacks, even with arguments
-
-# WIP - needs to be compatible with gosu/preview.rb later
-
-at_exit do
-  Gosu::ZenWindow.instance.show
+  
+  class ZenWindow < Window
+    
+    def button_down id
+      m = :"button_down_#{id}"
+      respond_to?(m) ? send(m) : button_down_other(id)
+    end
+    
+    def button_up id
+      m = :"button_up_#{id}"
+      respond_to?(m) ? send(m) : button_up_other(id)
+    end
+    
+    def button_down_other id
+    end
+    
+    def button_up_other id
+    end
+    
+  end
 end


### PR DESCRIPTION
This is a pretty big change from what was there before, but I think the interface (at least, what's not totally new) is mostly the same. The major difference is you have to `include Gosu::Zen` and it doesn't create the window until the `at_exit` callback.

Oh yeah, and it's using the preview API. I'm thinking of having `Zen.included` load the preview API and adding `require 'gosu/zen'` to gosu.rb. Any thoughts?
