### PR TITLE
Fixed rebuild up-to-date bug

### DIFF
--- a/windows/Gosu.vcxproj
+++ b/windows/Gosu.vcxproj
@@ -168,7 +168,6 @@
     <ClInclude Include="..\Gosu\Input.hpp" />
     <ClInclude Include="..\Gosu\Inspection.hpp" />
     <ClInclude Include="..\Gosu\IO.hpp" />
-    <ClInclude Include="..\Gosu\MacUtility.hpp" />
     <ClInclude Include="..\Gosu\Math.hpp" />
     <ClInclude Include="..\Gosu\Platform.hpp" />
     <ClInclude Include="..\GosuImpl\Sockets\Sockets.hpp" />

--- a/windows/Gosu.vcxproj.filters
+++ b/windows/Gosu.vcxproj.filters
@@ -290,9 +290,6 @@
     <ClInclude Include="..\Gosu\IO.hpp">
       <Filter>Interface</Filter>
     </ClInclude>
-    <ClInclude Include="..\Gosu\MacUtility.hpp">
-      <Filter>Interface</Filter>
-    </ClInclude>
     <ClInclude Include="..\Gosu\Math.hpp">
       <Filter>Interface</Filter>
     </ClInclude>


### PR DESCRIPTION
MSVS doesn't like it if you have files in the project that were deleted earlier (VS thinks the file is outdated, the builder however sees that everything is up-to-date - it's just a niggle, nothing seriois).

On that topic, one could probably add all missing files into the project (for example, FormattedString.hpp is missing..!)
