### PR TITLE
Gosu::milliseconds returns milliseconds since first call on Win/Unix

### DIFF
--- a/GosuImpl/TimingUnix.cpp
+++ b/GosuImpl/TimingUnix.cpp
@@ -9,10 +9,16 @@ void Gosu::sleep(unsigned milliseconds)
 
 unsigned long Gosu::milliseconds()
 {
+		static unsigned long start = 0;
+
     timeval tp;
     gettimeofday(&tp, NULL);
+
+		if (!start)
+			start = tp.tv_usec / 1000UL + tp.tv_sec * 1000UL;
+		
     // Truncate to 2^30, C++ users shouldn't mind and Ruby users will
     // have a happy GC on 32-bit systems.
     // No, don't ask why this is an unsigned long then :)
-    return (tp.tv_usec / 1000UL + tp.tv_sec * 1000UL) & 0x1fffffff;
+    return (tp.tv_usec / 1000UL + tp.tv_sec * 1000UL - start) & 0x1fffffff;
 }

--- a/GosuImpl/TimingWin.cpp
+++ b/GosuImpl/TimingWin.cpp
@@ -17,15 +17,16 @@ namespace
 
 unsigned long Gosu::milliseconds()
 {
-    static bool init = false;
-    if (!init)
+		static unsigned long start = 0;
+
+    if (!start)
     {
         if (::timeBeginPeriod(1) != TIMERR_NOERROR)
             std::atexit(resetTGT);
-        init = true;
+				start = ::timeGetTime();
     }
     // Truncate to 2^30, C++ users shouldn't mind and Ruby users will
     // have a happy GC on 32-bit systems.
     // No, don't ask why this is an unsigned long then :)
-    return ::timeGetTime() & 0x1fffffff;
+    return (::timeGetTime() - start) & 0x1fffffff;
 }


### PR DESCRIPTION
There's still this 149-runtime-days-overflow, but at least it won't happen "randomly" anymore.

(Is that 30bit thing still necessary though - and why doesn't it happen on Mac?)
