### PR TITLE
Fixed ambiguous call to std::abs()

### DIFF
--- a/GosuImpl/Graphics/DrawOpQueue.hpp
+++ b/GosuImpl/Graphics/DrawOpQueue.hpp
@@ -10,43 +10,44 @@
 #include <algorithm>
 #include <map>
 #include <vector>
+#include <cmath>
 
 class Gosu::DrawOpQueue
 {
     TransformStack transformStack;
     ClipRectStack clipRectStack;
-    
+
     typedef std::vector<DrawOp> DrawOps;
     DrawOps ops;
     typedef std::vector<std::tr1::function<void()> > GLBlocks;
     GLBlocks glBlocks;
-    
+
 public:
     void scheduleDrawOp(DrawOp op)
     {
         if (clipRectStack.clippedWorldAway())
             return;
-        
+
         #ifdef GOSU_IS_IPHONE
         // No triangles, no lines supported
         assert (op.verticesOrBlockIndex == 4);
         #endif
-        
+
         op.renderState.transform = &transformStack.current();
         if (const ClipRect* cr = clipRectStack.maybeEffectiveRect())
             op.renderState.clipRect = *cr;
         ops.push_back(op);
     }
-    
+
     void scheduleGL(std::tr1::function<void()> glBlock, ZPos z)
     {
         // TODO: Document this case: Clipped-away GL blocks are *not* being run.
         if (clipRectStack.clippedWorldAway())
             return;
-        
+
         int complementOfBlockIndex = ~(int)glBlocks.size();
         glBlocks.push_back(glBlock);
-        
+
         DrawOp op;
         op.verticesOrBlockIndex = complementOfBlockIndex;
         op.renderState.transform = &transformStack.current();
@@ -55,60 +56,60 @@ public:
         op.z = z;
         ops.push_back(op);
     }
-    
+
     void beginClipping(double x, double y, double width, double height, double screenHeight)
     {
         // Apply current transformation.
-        
+
         double left = x, right = x + width;
         double top = y, bottom = y + height;
-        
+
         applyTransform(transformStack.current(), left, top);
         applyTransform(transformStack.current(), right, bottom);
-        
+
         double physX = std::min(left, right);
         double physY = std::min(top, bottom);
         double physWidth = std::abs(left - right);
         double physHeight = std::abs(top - bottom);
-        
+
         // Adjust for OpenGL having the wrong idea of where y=0 is.
         // TODO: This should really happen *right before* setting up
         // the glScissor.
         physY = screenHeight - physY - physHeight;
-        
+
         clipRectStack.beginClipping(physX, physY, physWidth, physHeight);
     }
-    
+
     void endClipping()
     {
         clipRectStack.endClipping();
     }
-    
+
     void setBaseTransform(const Transform& baseTransform)
     {
         transformStack.setBaseTransform(baseTransform);
     }
-    
+
     void pushTransform(const Transform& transform)
     {
         transformStack.push(transform);
     }
-    
+
     void popTransform()
     {
         transformStack.pop();
     }
-    
+
     void performDrawOpsAndCode()
     {
         // Apply Z-Ordering.
         std::stable_sort(ops.begin(), ops.end());
-        
+
         RenderStateManager manager;
         #ifdef GOSU_IS_IPHONE
         if (ops.empty())
             return;
-        
+
         DrawOps::const_iterator current = ops.begin(), last = ops.end() - 1;
         for (; current != last; ++current)
         {
@@ -136,24 +137,24 @@ public:
         }
         #endif
     }
-    
+
     void compileTo(VertexArrays& vas)
     {
         if (!glBlocks.empty())
             throw std::logic_error("Custom code cannot be recorded into a macro");
-        
+
         std::stable_sort(ops.begin(), ops.end());
         for (DrawOps::const_iterator op = ops.begin(), end = ops.end(); op != end; ++op)
             op->compileTo(vas);
     }
-    
+
     // This retains the current stack of transforms and clippings.
     void clearQueue()
     {
         glBlocks.clear();
         ops.clear();
     }
-    
+
     // This clears the queue and starts with new stacks. This must not be called
     // when endClipping/popTransform calls might still be pending.
     void reset()


### PR DESCRIPTION
The C standard library requires fabs() to be called for floating point
numbers, while the C++ standard library overloads abs(). The inclusion
of cmath in DrawOpQueue.hpp fixes the error on GCC 4.7.
