### PR TITLE
More c++11

### DIFF
--- a/Gosu/Font.hpp
+++ b/Gosu/Font.hpp
@@ -30,7 +30,7 @@ namespace Gosu
         //! \param fontFlags Flags used to render individual characters of
         //!        the font.
         Font(Graphics& graphics, const std::wstring& fontName,
-            unsigned fontHeight, unsigned fontFlags = ffBold);
+            unsigned fontHeight, FontFlags fontFlags = ffBold);
         
         //! Returns the name of the font that was used to create it.
         std::wstring name() const;
@@ -39,7 +39,7 @@ namespace Gosu
         unsigned height() const;
         
         //! Returns the flags used to create the font characters.
-        unsigned flags() const;
+        FontFlags flags() const;
         
         //! Returns the width, in pixels, the given text would occupy if drawn.
         double textWidth(const std::wstring& text, double factorX = 1) const;
@@ -64,7 +64,7 @@ namespace Gosu
         //! Gosu's built-in text rendering. This can only be called once per
         //! character, and the character must not have been drawn before.
         //! This ensures that Fonts are still sort of immutable.
-        void setImage(wchar_t wc, unsigned fontFlags, const Gosu::Image& image);
+        void setImage(wchar_t wc, FontFlags fontFlags, const Gosu::Image& image);
         //! A shortcut for mapping a character to an image regardless of fontFlags.
         //! Later versions might apply faux italics or faux bold to it (to be decided!).
         void setImage(wchar_t wc, const Gosu::Image& image);

--- a/Gosu/GraphicsBase.hpp
+++ b/Gosu/GraphicsBase.hpp
@@ -59,6 +59,19 @@ namespace Gosu
         ffCombinations = 8
     };
     
+#if defined(GOSU_CPP11_ENABLED)
+    enum class TextAlign
+    {
+        Left,
+        Right,
+        Center,
+        Justify
+    };
+    GOSU_DEPRECATED static const TextAlign taLeft = TextAlign::Left;
+    GOSU_DEPRECATED static const TextAlign taRight = TextAlign::Right;
+    GOSU_DEPRECATED static const TextAlign taCenter = TextAlign::Center;
+    GOSU_DEPRECATED static const TextAlign taJustify = TextAlign::Justify;
+#else
     enum TextAlign
     {
         taLeft,
@@ -66,6 +79,7 @@ namespace Gosu
         taCenter,
         taJustify
     };
+#endif
     
     //! Flags that affect the tileability of an image.
     enum BorderFlags

--- a/Gosu/GraphicsBase.hpp
+++ b/Gosu/GraphicsBase.hpp
@@ -6,6 +6,9 @@
 
 #include <Gosu/Platform.hpp>
 #include <limits>
+#if defined(GOSU_CPP11_ENABLED)
+#include <type_traits>
+#endif
 
 namespace Gosu
 {
@@ -51,13 +54,55 @@ namespace Gosu
     };
 #endif
     
+#if defined(GOSU_CPP11_ENABLED)
+    enum class FontFlags
+    {
+        NONE = 0,
+        BOLD = 1,
+        ITALIC = 2,
+        UNDERLINE = 4
+    };
+    static const typename std::underlying_type<FontFlags>::type FontFlagCombinations = 8;
+    GOSU_DEPRECATED static const typename std::underlying_type<FontFlags>::type ffCombinations = FontFlagCombinations;
+    GOSU_DEPRECATED static const FontFlags ffNone = FontFlags::NONE;
+    GOSU_DEPRECATED static const FontFlags ffBold = FontFlags::BOLD;
+    GOSU_DEPRECATED static const FontFlags ffItalic = FontFlags::ITALIC;
+    GOSU_DEPRECATED static const FontFlags ffUnderline = FontFlags::UNDERLINE;
+    inline FontFlags operator|(const FontFlags& lhs, const FontFlags& rhs)
+    {
+        typedef typename std::underlying_type<FontFlags>::type int_type;
+        return static_cast<FontFlags>(static_cast<int_type>(lhs)|static_cast<int_type>(rhs));
+    }
+    inline FontFlags operator&(const FontFlags& lhs, const FontFlags& rhs)
+    {
+        typedef typename std::underlying_type<FontFlags>::type int_type;
+        return static_cast<FontFlags>(static_cast<int_type>(lhs)&static_cast<int_type>(rhs));
+    }
+    inline FontFlags& operator|=(FontFlags& lhs, const FontFlags& rhs)
+    {
+        lhs = lhs | rhs;
+        return lhs;
+    }
+    inline FontFlags& operator&=(FontFlags& lhs, const FontFlags& rhs)
+    {
+        lhs = lhs & rhs;
+        return lhs;
+    }
+    inline FontFlags operator~(const FontFlags& rhs)
+    {
+        typedef typename std::underlying_type<FontFlags>::type int_type;
+        return static_cast<FontFlags>(~static_cast<int_type>(rhs));
+    }
+#else
     enum FontFlags
     {
+        ffNone         = 0,
         ffBold         = 1,
         ffItalic       = 2,
-        ffUnderline    = 4,
-        ffCombinations = 8
+        ffUnderline    = 4
     };
+    static const size_t ffCombinations = 8;
+#endif
     
 #if defined(GOSU_CPP11_ENABLED)
     enum class TextAlign

--- a/Gosu/Text.hpp
+++ b/Gosu/Text.hpp
@@ -22,7 +22,7 @@ namespace Gosu
     //! \param fontName Name of a system font, or a filename to a TTF file (must contain '/').
     unsigned textWidth(const std::wstring& text,
         const std::wstring& fontName, unsigned fontHeight,
-        unsigned fontFlags = 0);
+        FontFlags fontFlags = ffNone);
 
     //! Draws a line of unformatted text on a bitmap. This is a very low-level function that does not understand
     //! any of Gosu's HTML-like markup.
@@ -33,7 +33,7 @@ namespace Gosu
     //! enum.
     void drawText(Bitmap& bitmap, const std::wstring& text, int x, int y,
         Color c, const std::wstring& fontName, unsigned fontHeight,
-        unsigned fontFlags = 0);
+        FontFlags fontFlags = ffNone);
 
     //! Creates a bitmap that is filled with a line of formatted text given to the function.
     //! The line can contain line breaks and HTML-like markup.
@@ -44,7 +44,7 @@ namespace Gosu
     //! enum.
     Bitmap createText(const std::wstring& text,
         const std::wstring& fontName, unsigned fontHeight,
-        unsigned fontFlags = 0);
+        FontFlags fontFlags = ffNone);
 
     //! Creates a bitmap that is filled with the formatted text given to the function.
     //! The line can contain line breaks and HTML-like markup.
@@ -61,7 +61,7 @@ namespace Gosu
     Bitmap createText(const std::wstring& text,
         const std::wstring& fontName, unsigned fontHeight, 
         int lineSpacing, unsigned width, TextAlign align,
-        unsigned fontFlags = 0);
+        FontFlags fontFlags = ffNone);
     
     //! Registers a new HTML-style entity that can subsequently be used
     //! with Gosu::Font and Gosu::createText. The name is given without & and ;.

--- a/GosuImpl/Graphics/Font.cpp
+++ b/GosuImpl/Graphics/Font.cpp
@@ -14,7 +14,8 @@ struct Gosu::Font::Impl
 {
     Graphics* graphics;
     wstring name;
-    unsigned height, flags;
+    unsigned height;
+    FontFlags flags;
 
     // Unicode planes of 2^16 characters each. On Windows, where wchar_t is only 16 bits wide, only
     // the first plane will ever be touched.
@@ -28,19 +29,22 @@ struct Gosu::Font::Impl
     
     map<wstring, tr1::shared_ptr<Image> > entityCache;
     
-    CharInfo& charInfo(wchar_t wc, unsigned flags)
+    CharInfo& charInfo(wchar_t wc, FontFlags flags)
     {
         size_t planeIndex = wc / 65536;
         size_t charIndex  = wc % 65536;
         
+        typedef typename std::underlying_type<FontFlags>::type int_type;
+        int_type int_flags = static_cast<int_type>(flags);
+        
         if (planeIndex >= 16)
             throw invalid_argument("Unicode plane out of reach");
-        if (flags >= ffCombinations)
+        if (int_flags >= ffCombinations)
             throw invalid_argument("Font flags out of range");
         
-        if (!planes[planeIndex][flags].get())
-            planes[planeIndex][flags].reset(new Plane);
-        return (*planes[planeIndex][flags])[charIndex];
+        if (!planes[planeIndex][int_flags].get())
+            planes[planeIndex][int_flags].reset(new Plane);
+        return (*planes[planeIndex][int_flags])[charIndex];
     }
     
     const Image& imageAt(const FormattedString& fs, unsigned i)
@@ -54,7 +58,7 @@ struct Gosu::Font::Impl
         }
         
         wchar_t wc = fs.charAt(i);
-        unsigned flags = fs.flagsAt(i);
+        FontFlags flags = fs.flagsAt(i);
         CharInfo& info = charInfo(wc, flags);
         
         if (info.image.get())
@@ -82,7 +86,7 @@ struct Gosu::Font::Impl
 };
 
 Gosu::Font::Font(Graphics& graphics, const wstring& fontName, unsigned fontHeight,
-    unsigned fontFlags)
+    FontFlags fontFlags)
 : pimpl(new Impl)
 {
     pimpl->graphics = &graphics;
@@ -101,7 +105,7 @@ unsigned Gosu::Font::height() const
     return pimpl->height / 2;
 }
 
-unsigned Gosu::Font::flags() const
+Gosu::FontFlags Gosu::Font::flags() const
 {
     return pimpl->flags;
 }
@@ -148,11 +152,12 @@ void Gosu::Font::drawRel(const wstring& text, double x, double y, ZPos z,
 
 void Gosu::Font::setImage(wchar_t wc, const Image& image)
 {
-    for (unsigned flags = 0; flags < ffCombinations; ++flags)
-        setImage(wc, flags, image);
+    typedef typename std::underlying_type<FontFlags>::type int_type;
+    for (int_type flags = 0; flags < ffCombinations; ++flags)
+        setImage(wc, static_cast<FontFlags>(flags), image);
 }
 
-void Gosu::Font::setImage(wchar_t wc, unsigned fontFlags, const Image& image)
+void Gosu::Font::setImage(wchar_t wc, FontFlags fontFlags, const Image& image)
 {
     Impl::CharInfo& ci = pimpl->charInfo(wc, fontFlags);
     if (ci.image.get())

--- a/GosuImpl/Graphics/FormattedString.hpp
+++ b/GosuImpl/Graphics/FormattedString.hpp
@@ -19,7 +19,7 @@ namespace Gosu
         {
             wchar_t wc;
             Gosu::Color color;
-            unsigned flags;
+            FontFlags flags;
             std::wstring entity;
             
             bool sameStyleAs(const FormattedChar& other) const
@@ -30,13 +30,13 @@ namespace Gosu
         
         // If characters.empty(), use these for the whole string.
         std::wstring simpleString;
-        unsigned simpleFlags;
+        FontFlags simpleFlags;
         // If not characters.empty(), ignore above fields and use this.
         std::vector<FormattedChar> characters;
         
-        static unsigned flags(int b, int u, int i)
+        static FontFlags flags(int b, int u, int i)
         {
-            unsigned flags = 0;
+            FontFlags flags = FontFlags::NONE;
             if (b > 0) flags |= ffBold;
             if (u > 0) flags |= ffUnderline;
             if (i > 0) flags |= ffItalic;
@@ -48,7 +48,7 @@ namespace Gosu
         {
         }
         
-        explicit FormattedString(const wchar_t* html, unsigned baseFlags)
+        explicit FormattedString(const wchar_t* html, FontFlags baseFlags)
         {
             // Remove \r characters if existent. Avoid a copy if we don't need one.
             std::wstring unixified;
@@ -76,9 +76,9 @@ namespace Gosu
             }
             
             unsigned pos = 0;
-            int b = (baseFlags & ffBold) ? 1 : 0,
-                u = (baseFlags & ffUnderline) ? 1 : 0,
-                i = (baseFlags & ffItalic) ? 1 : 0;
+            int b = ((baseFlags & ffBold) == ffBold) ? 1 : 0,
+                u = ((baseFlags & ffUnderline) == ffBold) ? 1 : 0,
+                i = ((baseFlags & ffItalic) == ffBold) ? 1 : 0;
             std::vector<Gosu::Color> c;
             c.push_back(0xffffffff);
             while (pos < len)
@@ -179,7 +179,7 @@ namespace Gosu
                         if (endOfEntity >= len)
                             goto normalCharacter;
                     }
-                    FormattedChar fc = { 0, c.back(), 0, std::wstring(html + pos + 1, html + endOfEntity) };
+                    FormattedChar fc = { 0, c.back(), FontFlags::NONE, std::wstring(html + pos + 1, html + endOfEntity) };
                     if (!isEntity(fc.entity))
                         goto normalCharacter;
                     characters.push_back(fc);
@@ -225,7 +225,7 @@ namespace Gosu
                 return characters[index].wc;
         }
         
-        unsigned flagsAt(unsigned index) const
+        FontFlags flagsAt(unsigned index) const
         {
             if (characters.empty())
                 return simpleFlags;

--- a/GosuImpl/Graphics/Text.cpp
+++ b/GosuImpl/Graphics/Text.cpp
@@ -85,7 +85,7 @@ namespace Gosu
                 this->lineSpacing = lineSpacing;
                 this->align = align;
 
-                spaceWidth_ = textWidth(FormattedString(L" ", 0));
+                spaceWidth_ = textWidth(FormattedString(L" ", ffNone));
             }
 
             unsigned width() const
@@ -301,7 +301,7 @@ namespace Gosu
 
 Gosu::Bitmap Gosu::createText(const wstring& text,
     const wstring& fontName, unsigned fontHeight, int lineSpacing,
-    unsigned width, TextAlign align, unsigned fontFlags)
+    unsigned width, TextAlign align, FontFlags fontFlags)
 {
     if (lineSpacing <= -static_cast<int>(fontHeight))
         throw logic_error("negative line spacing of more than line height impossible");
@@ -323,7 +323,7 @@ Gosu::Bitmap Gosu::createText(const wstring& text,
 
 // Very easy special case.
 Gosu::Bitmap Gosu::createText(const wstring& text,
-    const wstring& fontName, unsigned fontHeight, unsigned fontFlags)
+    const wstring& fontName, unsigned fontHeight, FontFlags fontFlags)
 {
     FormattedString fs(text.c_str(), fontFlags);
     if (fs.length() == 0)

--- a/GosuImpl/Graphics/TextUnix.cpp
+++ b/GosuImpl/Graphics/TextUnix.cpp
@@ -52,7 +52,7 @@ namespace Gosu
         }
         unsigned textWidth(const std::wstring& text,
             const std::wstring& fontFace, unsigned fontHeight,
-            unsigned fontFlags)
+            FontFlags fontFlags)
         {
             g_type_init();
 
@@ -69,10 +69,10 @@ namespace Gosu
             pango_font_description_set_family(font_description,
                 g_strdup(narrow(fontFace).c_str()));
             pango_font_description_set_style(font_description,
-                (fontFlags & ffItalic) ? PANGO_STYLE_ITALIC : PANGO_STYLE_NORMAL);
+                ((fontFlags & ffItalic) == ffItalic) ? PANGO_STYLE_ITALIC : PANGO_STYLE_NORMAL);
             pango_font_description_set_variant(font_description, PANGO_VARIANT_NORMAL);
             pango_font_description_set_weight(font_description,
-                (fontFlags & ffBold) ? PANGO_WEIGHT_BOLD : PANGO_WEIGHT_NORMAL);
+                ((fontFlags & ffBold) == ffBold) ? PANGO_WEIGHT_BOLD : PANGO_WEIGHT_NORMAL);
             pango_font_description_set_stretch(font_description, PANGO_STRETCH_NORMAL);
             int init_scale = int(fontHeight/2.0 + 0.5);
             pango_font_description_set_size(font_description, init_scale * PANGO_SCALE);
@@ -83,7 +83,7 @@ namespace Gosu
             layout = pango_layout_new(context);
 
 
-            if(fontFlags & ffUnderline)
+            if((fontFlags & ffUnderline) == ffUnderline)
             {
         //        PangoAttribute *attr;
                 attr = pango_attr_underline_new(PANGO_UNDERLINE_SINGLE);
@@ -118,7 +118,7 @@ namespace Gosu
         }
         void drawText(Bitmap& bitmap, const std::wstring& text, int x, int y,
             Color c, const std::wstring& fontFace, unsigned fontHeight,
-            unsigned fontFlags)
+            FontFlags fontFlags)
         {
             textWidth(text, fontFace, fontHeight, fontFlags);
 
@@ -251,7 +251,7 @@ namespace Gosu
 
 unsigned Gosu::textWidth(const std::wstring& text,
     const std::wstring& fontName, unsigned fontHeight,
-    unsigned fontFlags)
+    FontFlags fontFlags)
 {
     if (text.find_first_of(L"\r\n") != std::wstring::npos)
         throw std::invalid_argument("the argument to textWidth cannot contain line breaks");
@@ -264,7 +264,7 @@ unsigned Gosu::textWidth(const std::wstring& text,
 
 void Gosu::drawText(Bitmap& bitmap, const std::wstring& text, int x, int y,
     Color c, const std::wstring& fontName, unsigned fontHeight,
-    unsigned fontFlags)
+    FontFlags fontFlags)
 {
     if (text.find_first_of(L"\r\n") != std::wstring::npos)
         throw std::invalid_argument("the argument to drawText cannot contain line breaks");


### PR DESCRIPTION
where do you want the FontFlags operator implementations? the header file is not quite the right place for it
and what should i do about the other operating systems? i can't test the code there and they definitely won't compile if c++11 is detected (with the changes in this PR, the other one should be fine)
