### PR TITLE
Use existing methods for angle calculations

### DIFF
--- a/examples/ChipmunkIntegration.rb
+++ b/examples/ChipmunkIntegration.rb
@@ -19,13 +19,6 @@ SCREEN_HEIGHT = 480
 # Chipmunk step calls per update will effectively avoid this issue
 SUBSTEPS = 6
 
-# Convenience method for converting from radians to a Vec2 vector.
-class Numeric
-  def radians_to_vec2
-    CP::Vec2.new(Math::cos(self), Math::sin(self))
-  end
-end
-
 # Layering of sprites
 module ZOrder
   Background, Stars, Player, UI = *0..3
@@ -40,32 +33,32 @@ class Player
     @shape = shape
     @shape.body.p = CP::Vec2.new(0.0, 0.0) # position
     @shape.body.v = CP::Vec2.new(0.0, 0.0) # velocity
-    
+
     # Keep in mind that down the screen is positive y, which means that PI/2 radians,
     # which you might consider the top in the traditional Trig unit circle sense is actually
     # the bottom; thus 3PI/2 is the top
-    @shape.body.a = (3*Math::PI/2.0) # angle in radians; faces towards top of screen
+    @shape.body.a = 0.gosu_to_radians # angle in radians; faces towards top of screen
   end
-  
+
   # Directly set the position of our Player
   def warp(vect)
     @shape.body.p = vect
   end
-  
+
   # Apply negative Torque; Chipmunk will do the rest
   # SUBSTEPS is used as a divisor to keep turning rate constant
   # even if the number of steps per update are adjusted
   def turn_left
     @shape.body.t -= 400.0/SUBSTEPS
   end
-  
+
   # Apply positive Torque; Chipmunk will do the rest
   # SUBSTEPS is used as a divisor to keep turning rate constant
   # even if the number of steps per update are adjusted
   def turn_right
     @shape.body.t += 400.0/SUBSTEPS
   end
-  
+
   # Apply forward force; Chipmunk will do the rest
   # SUBSTEPS is used as a divisor to keep acceleration rate constant
   # even if the number of steps per update are adjusted
@@ -73,27 +66,27 @@ class Player
   # forward momentum by creating a vector in the direction of the facing
   # and with a magnitude representing the force we want to apply
   def accelerate
-    @shape.body.apply_force((@shape.body.a.radians_to_vec2 * (3000.0/SUBSTEPS)), CP::Vec2.new(0.0, 0.0))
+    @shape.body.apply_force((@shape.body.rot * (3000.0/SUBSTEPS)), CP::Vec2.new(0.0, 0.0))
   end
-  
+
   # Apply even more forward force
   # See accelerate for more details
   def boost
-    @shape.body.apply_force((@shape.body.a.radians_to_vec2 * (3000.0)), CP::Vec2.new(0.0, 0.0))
+    @shape.body.apply_force((@shape.body.rot * (3000.0)), CP::Vec2.new(0.0, 0.0))
   end
-  
+
   # Apply reverse force
   # See accelerate for more details
   def reverse
-    @shape.body.apply_force(-(@shape.body.a.radians_to_vec2 * (1000.0/SUBSTEPS)), CP::Vec2.new(0.0, 0.0))
+    @shape.body.apply_force(-(@shape.body.rot * (1000.0/SUBSTEPS)), CP::Vec2.new(0.0, 0.0))
   end
-  
+
   # Wrap to the other side of the screen when we fly off the edge
   def validate_position
     l_position = CP::Vec2.new(@shape.body.p.x % SCREEN_WIDTH, @shape.body.p.y % SCREEN_HEIGHT)
     @shape.body.p = l_position
   end
-  
+
   def draw
     @image.draw_rot(@shape.body.p.x, @shape.body.p.y, ZOrder::Player, @shape.body.a.radians_to_gosu)
   end
@@ -103,7 +96,7 @@ end
 # Of course... it just sits around and looks good...
 class Star
   attr_reader :shape
-  
+
   def initialize(animation, shape)
     @animation = animation
     @color = Gosu::Color.new(0xff000000)
@@ -113,11 +106,11 @@ class Star
     @shape = shape
     @shape.body.p = CP::Vec2.new(rand * SCREEN_WIDTH, rand * SCREEN_HEIGHT) # position
     @shape.body.v = CP::Vec2.new(0.0, 0.0) # velocity
-    @shape.body.a = (3*Math::PI/2.0) # angle in radians; faces towards top of screen
+    @shape.body.a = 0.gosu_to_radians # angle in radians; faces towards top of screen
   end
 
-  def draw  
-    img = @animation[Gosu::milliseconds / 100 % @animation.size];
+  def draw
+    img = @animation[Gosu::milliseconds / 100 % @animation.size]
     img.draw(@shape.body.p.x - img.width / 2.0, @shape.body.p.y - img.height / 2.0, ZOrder::Stars, 1, 1, @color, :add)
   end
 end
@@ -132,45 +125,45 @@ class GameWindow < Gosu::Window
 
     # Put the beep here, as it is the environment now that determines collision
     @beep = Gosu::Sample.new(self, "media/Beep.wav")
-    
+
     # Put the score here, as it is the environment that tracks this now
     @score = 0
     @font = Gosu::Font.new(self, Gosu::default_font_name, 20)
-    
+
     # Time increment over which to apply a physics "step" ("delta t")
     @dt = (1.0/60.0)
-    
+
     # Create our Space and set its damping
     # A damping of 0.8 causes the ship bleed off its force and torque over time
     # This is not realistic behavior in a vacuum of space, but it gives the game
     # the feel I'd like in this situation
     @space = CP::Space.new
-    @space.damping = 0.8    
-    
+    @space.damping = 0.8
+
     # Create the Body for the Player
     body = CP::Body.new(10.0, 150.0)
-    
+
     # In order to create a shape, we must first define it
     # Chipmunk defines 3 types of Shapes: Segments, Circles and Polys
     # We'll use s simple, 4 sided Poly for our Player (ship)
     # You need to define the vectors so that the "top" of the Shape is towards 0 radians (the right)
     shape_array = [CP::Vec2.new(-25.0, -25.0), CP::Vec2.new(-25.0, 25.0), CP::Vec2.new(25.0, 1.0), CP::Vec2.new(25.0, -1.0)]
     shape = CP::Shape::Poly.new(body, shape_array, CP::Vec2.new(0,0))
-    
+
     # The collision_type of a shape allows us to set up special collision behavior
     # based on these types.  The actual value for the collision_type is arbitrary
     # and, as long as it is consistent, will work for us; of course, it helps to have it make sense
     shape.collision_type = :ship
-    
+
     @space.add_body(body)
     @space.add_shape(shape)
 
     @player = Player.new(self, shape)
     @player.warp(CP::Vec2.new(320, 240)) # move to the center of the window
-    
+
     @star_anim = Gosu::Image::load_tiles(self, "media/Star.png", 25, 25, false)
     @stars = Array.new
-        
+
     # Here we define what is supposed to happen when a Player (ship) collides with a Star
     # I create a @remove_shapes array because we cannot remove either Shapes or Bodies
     # from Space within a collision closure, rather, we have to wait till the closure
@@ -185,7 +178,7 @@ class GameWindow < Gosu::Window
       @beep.play
       @remove_shapes << star_shape
     end
-    
+
     # Here we tell Space that we don't want one star bumping into another
     # The reason we need to do this is because when the Player hits a Star,
     # the Star will travel until it is removed in the update cycle below
@@ -211,16 +204,16 @@ class GameWindow < Gosu::Window
         @space.remove_shape(shape)
       end
       @remove_shapes.clear # clear out the shapes for next pass
-      
+
       # When a force or torque is set on a Body, it is cumulative
       # This means that the force you applied last SUBSTEP will compound with the
       # force applied this SUBSTEP; which is probably not the behavior you want
       # We reset the forces on the Player each SUBSTEP for this reason
       @player.shape.body.reset_forces
-      
+
       # Wrap around the screen to the other side
       @player.validate_position
-      
+
       # Check keyboard
       if button_down? Gosu::KbLeft
         @player.turn_left
@@ -228,7 +221,7 @@ class GameWindow < Gosu::Window
       if button_down? Gosu::KbRight
         @player.turn_right
       end
-      
+
       if button_down? Gosu::KbUp
         if ( (button_down? Gosu::KbRightShift) || (button_down? Gosu::KbLeftShift) )
           @player.boost
@@ -238,21 +231,21 @@ class GameWindow < Gosu::Window
       elsif button_down? Gosu::KbDown
         @player.reverse
       end
-      
+
       # Perform the step over @dt period of time
       # For best performance @dt should remain consistent for the game
       @space.step(@dt)
     end
-    
+
     # Each update (not SUBSTEP) we see if we need to add more Stars
     if rand(100) < 4 and @stars.size < 25 then
       body = CP::Body.new(0.0001, 0.0001)
       shape = CP::Shape::Circle.new(body, 25/2, CP::Vec2.new(0.0, 0.0))
       shape.collision_type = :star
-      
+
       @space.add_body(body)
       @space.add_shape(shape)
-      
+
       @stars.push(Star.new(@star_anim, shape))
     end
   end


### PR DESCRIPTION
Remove unneeded monkey patching of Numeric class, as the method CP::Body#rot can provide the unit angle vector used for applying forces. Use Gosu::gosu_to_radians to set angles.