### PR TITLE
Removed i386 architecture from ARCH_FLAG on Darwin

### DIFF
--- a/ext/gosu/extconf.rb
+++ b/ext/gosu/extconf.rb
@@ -92,6 +92,7 @@ if `uname`.chomp == 'Darwin' then
   $CFLAGS.gsub! "-arch i386", ""
   $CXXFLAGS.gsub! "-arch i386", ""
   $LDFLAGS.gsub! "-arch i386", ""
+  $ARCH_FLAG.gsub! "-arch i386", ""
   CONFIG['LDSHARED'].gsub! "-arch i386", ""
 else
   SOURCE_FILES = BASE_FILES + LINUX_FILES


### PR DESCRIPTION
Hi maintainer :)

On my Mac, `sudo gem install gosu` fails like this:

```
Building native extensions.  This could take a while...
ERROR:  Error installing gosu:
	ERROR: Failed to build gem native extension.

    /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/bin/ruby extconf.rb
The Gosu gem requires some libraries to be installed system-wide.
See the following site for a list:
https://github.com/gosu/gosu/wiki/Getting-Started-on-OS-X
creating Makefile

make "DESTDIR="
compiling stb_vorbis.c
error: -fobjc-arc is not supported on platforms using the legacy runtime
make: *** [stb_vorbis.o] Error 1


Gem files will remain installed in /Library/Ruby/Gems/2.0.0/gems/gosu-0.10.8 for inspection.
Results logged to /Library/Ruby/Gems/2.0.0/gems/gosu-0.10.8/ext/gosu/gem_make.out
```

I noticed that still have `-arch i386`  in `ARCH_FLAGS` in the `Makefile` even though they are cut out elsewhere in `extconf.rb`.  From what I understand, it's because building for 32-bit means we have to use the Objective C 1.0 runtime, which does not support ARC.  I removed this and it compiles and works OK for me now.

I suspect it is probably not this easy..is there some reason to not do this?  Is there anything else you'd like to see from me on this?

Thanks,
Cory

System: OS X 10.10.5, XCode 6.3.1 (with tools), ruby (system) `ruby 2.0.0p481 (2014-05-08 revision 45883) [universal.x86_64-darwin14]`