### PR TITLE
Remove (soon) retired Travis OSX image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ matrix:
       dist: trusty
       sudo: required
       compiler: gcc
-    # OS X 10.9 Mavericks
-    - os: osx
-      osx_image: beta-xcode6.2
-      compiler: clang
     # OS X 10.11 El Capitan
     - os: osx
       osx_image: xcode7.3


### PR DESCRIPTION
I stumbled upon the following Hint in travis while working on another PR for Gosu:

>  This job was configured to run on an OS X image that was retired on November 28, 2016. It was routed to our Xcode 6.4 infrastructure.
[Travis - Job #150.2](https://travis-ci.org/gosu/gosu/jobs/188226358)

Clicking on Xcode 6.4 the travis docs mention that 6.4 will be retired too on Friday, January 20th. Although there is no year mentioned I guess it will be 2017. So the newest available will be 7.3.x which is already in this list, so no need to do the build twice.