### PR TITLE
[WIP] Resolves #234 - Rework Gosu::VERSION and Gosu::LICENSES

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,7 @@ install:
 
 script:
   # Ruby/Gosu
-  - ruby -rgosu -e 'puts Gosu::VERSION'
+  - ruby -rgosu -e 'puts RUBY_VERSION, Gosu::VERSION, Gosu::LICENSES'
+
   # Compile C++ examples
   - mkdir -p examples/build && cd examples/build && cmake .. && make && cd ../..

--- a/Gosu/Version.hpp
+++ b/Gosu/Version.hpp
@@ -3,12 +3,9 @@
 #define GOSU_MAJOR_VERSION 0
 #define GOSU_MINOR_VERSION 10
 #define GOSU_POINT_VERSION 8
-#define GOSU_VERSION "0.10.8"
 
-#define GOSU_COPYRIGHT_NOTICE \
-    "This software uses the following third-party libraries:\n" \
-    "\n" \
-    "Gosu, https://www.libgosu.org, MIT License, http://opensource.org/licenses/MIT\n" \
-    "SDL 2, http://www.libsdl.org, MIT License, http://opensource.org/licenses/MIT\n" \
-    "libsndfile, http://www.mega-nerd.com/libsndfile, GNU LGPL 3, http://www.gnu.org/copyleft/lesser.html\n" \
-    "OpenAL Soft, http://kcat.strangesoft.net/openal.html, GNU LGPL 2, http://www.gnu.org/licenses/old-licenses/lgpl-2.0.html\n"
+namespace Gosu
+{
+    extern const std::string VERSION;
+    extern const std::string LICENSES;
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,10 +27,10 @@ after_build:
 
     If ($env:PLATFORM -Eq "x64") {
       $env:PATH = "C:\Ruby23-x64\bin;$OLD_PATH"
-      ruby -I. -r./gosu.rb -e "puts RUBY_VERSION, Gosu::VERSION"
+      ruby -I. -r./gosu.rb -e "puts RUBY_VERSION, Gosu::VERSION, Gosu::LICENSES"
     }
     Else {
       $env:PATH = "C:\Ruby23\bin;$OLD_PATH"
-      ruby -I. -r./gosu.rb -e "puts RUBY_VERSION, Gosu::VERSION"
+      ruby -I. -r./gosu.rb -e "puts RUBY_VERSION, Gosu::VERSION, Gosu::LICENSES"
     }
 test: off

--- a/ext/gosu/gosu.i
+++ b/ext/gosu/gosu.i
@@ -379,7 +379,10 @@ namespace Gosu
 %rename("MAJOR_VERSION") GOSU_MAJOR_VERSION;
 %rename("MINOR_VERSION") GOSU_MINOR_VERSION;
 %rename("POINT_VERSION") GOSU_POINT_VERSION;
-%rename("VERSION") GOSU_VERSION;
+%ignore Gosu::VERSION;
+%ignore Gosu::LICENSES;
+%constant std::string VERSION = Gosu::VERSION;
+%constant std::string LICENSES = Gosu::LICENSES;
 %include "../../Gosu/Version.hpp"
 
 // Miscellaneous functions (timing, math)

--- a/ext/gosu/gosu_SWIG_RENAME_PATCH.patch
+++ b/ext/gosu/gosu_SWIG_RENAME_PATCH.patch
@@ -60,3 +60,16 @@
 -  result = rb_funcall(swig_get_self(), rb_intern("button_up"), 1,obj0);
 +  result = rb_funcall(swig_get_self(), rb_intern("protected_button_up"), 1,obj0);
  }
+
+
+@@ -11515,8 +11515,8 @@ SWIGEXPORT void Init_gosu(void) {
+   }
+
+   SWIG_RubyInitializeTrackings();
+-  rb_define_const(mGosu, "VERSION", SWIG_NewPointerObj(SWIG_as_voidptr(&Gosu::VERSION),SWIGTYPE_p_std__string, 0 ));
+-  rb_define_const(mGosu, "LICENSES", SWIG_NewPointerObj(SWIG_as_voidptr(&Gosu::LICENSES),SWIGTYPE_p_std__string, 0 ));
++  rb_define_const(mGosu, "VERSION", SWIG_From_std_string(static_cast< std::string >(Gosu::VERSION)));
++  rb_define_const(mGosu, "LICENSES", SWIG_From_std_string(static_cast< std::string >(Gosu::LICENSES)));
+   rb_define_const(mGosu, "MAJOR_VERSION", SWIG_From_int(static_cast< int >(0)));
+   rb_define_const(mGosu, "MINOR_VERSION", SWIG_From_int(static_cast< int >(10)));
+   rb_define_const(mGosu, "POINT_VERSION", SWIG_From_int(static_cast< int >(8)));

--- a/lib/gosu/patches.rb
+++ b/lib/gosu/patches.rb
@@ -4,15 +4,15 @@ class ::Numeric
   def degrees_to_radians
     self * Math::PI / 180.0
   end
-  
+
   def radians_to_degrees
     self * 180.0 / Math::PI
   end
-  
+
   def gosu_to_radians
     (self - 90) * Math::PI / 180.0
   end
-  
+
   def radians_to_gosu
     self * 180.0 / Math::PI + 90
   end
@@ -40,7 +40,7 @@ end
 # Passing a Window to initialize and from_text has been deprecated in Gosu 0.9.
 class Gosu::Image
   alias initialize_without_window initialize
-  
+
   def initialize(*args)
     if args[0].is_a? Gosu::Window then
       if args.size == 7 then
@@ -52,11 +52,11 @@ class Gosu::Image
       initialize_without_window(*args)
     end
   end
-  
+
   class << self
     alias from_text_without_window from_text
   end
-  
+
   def self.from_text(*args)
     if args.size == 4
       from_text_without_window(args[1], args[3], :font => args[2])
@@ -73,7 +73,7 @@ end
 # Passing a Window to Sample#initialize has been deprecated in Gosu 0.7.17.
 class Gosu::Sample
   alias initialize_without_window initialize
-  
+
   def initialize(*args)
     args.shift if args.first.is_a? Gosu::Window
     initialize_without_window(*args)
@@ -84,7 +84,7 @@ end
 # Passing a Window to Song#initialize has been deprecated in Gosu 0.7.17.
 class Gosu::Song
   alias initialize_without_window initialize
-  
+
   def initialize(*args)
     args.shift if args.first.is_a? Gosu::Window
     initialize_without_window(*args)
@@ -97,7 +97,7 @@ module Gosu
   class ImmutableColor < Color
     private :alpha=, :red=, :green=, :blue=, :hue=, :saturation=, :value=
   end
-  
+
   class Color
     NONE    = Gosu::ImmutableColor.new(0x00_000000)
     BLACK   = Gosu::ImmutableColor.new(0xff_000000)
@@ -121,18 +121,18 @@ end
 class Gosu::Window
   # Backwards compatibility:
   # Class methods that have been turned into module methods.
-  
+
   def self.button_id_to_char(id)
     Gosu.button_id_to_char(id)
   end
-  
+
   def self.char_to_button_id(ch)
     Gosu.char_to_button_id(ch)
   end
-  
+
   # Backwards compatibility:
   # Instance methods that have been turned into module methods.
-  
+
   %w(draw_line draw_triangle draw_quad
      flush gl clip_to record
      transform translate rotate scale
@@ -141,17 +141,21 @@ class Gosu::Window
       Gosu.send method, *args, &block
     end
   end
-  
+
   # Call Thread.pass every tick, which may or may not be necessary for friendly co-existence with
   # Ruby's Thread class.
-  
+
   alias _tick tick
-  
+
   def tick
     Thread.pass
     _tick
   end
 end
+
+# Backwards compatibility:
+# This was renamed, because it's not actually a "copyright notice" (Wikipedia: https://en.wikipedia.org/wiki/Copyright_notice).
+Gosu::GOSU_COPYRIGHT_NOTICE = Gosu::LICENSES
 
 # Release OpenAL resources during Ruby's shutdown, not Gosu's.
 at_exit do

--- a/rake/set_version.rb
+++ b/rake/set_version.rb
@@ -1,12 +1,3 @@
-LICENSES = <<-EOF
-  This software uses the following third-party libraries:
-  
-  Gosu, https://www.libgosu.org, MIT License, http://opensource.org/licenses/MIT
-  SDL 2, http://www.libsdl.org, MIT License, http://opensource.org/licenses/MIT
-  libsndfile, http://www.mega-nerd.com/libsndfile, GNU LGPL 3, http://www.gnu.org/copyleft/lesser.html
-  OpenAL Soft, http://kcat.strangesoft.net/openal.html, GNU LGPL 2, http://www.gnu.org/licenses/old-licenses/lgpl-2.0.html
-EOF
-
 task :set_version do
   throw "GOSU_RELEASE_VERSION must be set" if GOSU_VERSION == "0.0.0"
   
@@ -27,10 +18,12 @@ task :set_version do
 #define GOSU_MAJOR_VERSION #{major}
 #define GOSU_MINOR_VERSION #{minor}
 #define GOSU_POINT_VERSION #{patch}
-#define GOSU_VERSION "#{GOSU_VERSION}"
 
-#define GOSU_COPYRIGHT_NOTICE \\
-#{LICENSES.split("\n").map { |line| "    \"#{line.gsub(/^ */, "")}\\n\"" }.join(" \\\n")}
+namespace Gosu
+{
+    extern const std::string VERSION;
+    extern const std::string LICENSES;
+}
     EOF
   end
 end

--- a/rdoc/gosu.rb
+++ b/rdoc/gosu.rb
@@ -1,22 +1,26 @@
 ##
 # The first component of the version.
-GOSU_MAJOR_VERSION = :an_integer
+MAJOR_VERSION = :a_fixnum
 
 ##
 # The second component of the version.
-GOSU_MINOR_VERSION = :an_integer
+MINOR_VERSION = :a_fixnum
 
 ##
 # The third component of the version.
-GOSU_POINT_VERSION = :an_integer
+POINT_VERSION = :a_fixnum
 
 ##
 # A version string of the form "0.1.2", "0.1.2.3" or "0.1.2pre4".
-GOSU_VERSION = :a_string
+VERSION = :a_string
 
 ##
-# A long block of legal copy that your game is obliged to display somewhere.
+# @deprecated Use LICENSES instead as its a more appropriate name
+#
 GOSU_COPYRIGHT_NOTICE = :a_string
+
+# A long block of legal copy that your game is obliged to display somewhere.
+LICENSES = :a_string
 
 module Gosu
   Kb0 Kb1 Kb2 Kb3 Kb4 Kb5 Kb6 Kb7 Kb8 Kb9 = :implementation_defined

--- a/rdoc/gosu.rb
+++ b/rdoc/gosu.rb
@@ -1,28 +1,28 @@
-##
-# The first component of the version.
-MAJOR_VERSION = :a_fixnum
-
-##
-# The second component of the version.
-MINOR_VERSION = :a_fixnum
-
-##
-# The third component of the version.
-POINT_VERSION = :a_fixnum
-
-##
-# A version string of the form "0.1.2", "0.1.2.3" or "0.1.2pre4".
-VERSION = :a_string
-
-##
-# @deprecated Use LICENSES instead as its a more appropriate name
-#
-GOSU_COPYRIGHT_NOTICE = :a_string
-
-# A long block of legal copy that your game is obliged to display somewhere.
-LICENSES = :a_string
-
 module Gosu
+  ##
+  # The first component of the version.
+  MAJOR_VERSION = :a_fixnum
+
+  ##
+  # The second component of the version.
+  MINOR_VERSION = :a_fixnum
+
+  ##
+  # The third component of the version.
+  POINT_VERSION = :a_fixnum
+
+  ##
+  # A version string of the form "0.1.2", "0.1.2.3" or "0.1.2pre4".
+  VERSION = :a_string
+
+  ##
+  # @deprecated Use LICENSES instead as its a more appropriate name
+  GOSU_COPYRIGHT_NOTICE = :a_string
+
+  ##
+  # A long block of legal copy that your game is obliged to display somewhere.
+  LICENSES = :a_string
+
   Kb0 Kb1 Kb2 Kb3 Kb4 Kb5 Kb6 Kb7 Kb8 Kb9 = :implementation_defined
   KbA KbB KbC KbD KbE KbF KbG KbH KbI KbJ KbK KbL KbM KbN KbO KbP KbQ KbR KbS KbT KbU KbV KbW KbX KbY KbZ = :implementation_defined
   KbBackspace = :implementation_defined

--- a/src/RubyGosu.cxx
+++ b/src/RubyGosu.cxx
@@ -2204,8 +2204,9 @@ namespace Swig {
 #define SWIGTYPE_p_char swig_types[10]
 #define SWIGTYPE_p_double swig_types[11]
 #define SWIGTYPE_p_std__arrayT_double_16_t swig_types[12]
-static swig_type_info *swig_types[14];
-static swig_module_info swig_module = {swig_types, 13, 0, 0, 0, 0};
+#define SWIGTYPE_p_std__string swig_types[13]
+static swig_type_info *swig_types[15];
+static swig_module_info swig_module = {swig_types, 14, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -2498,43 +2499,6 @@ SWIG_From_int  (int value)
 }
 
 
-SWIGINTERN swig_type_info*
-SWIG_pchar_descriptor(void)
-{
-  static int init = 0;
-  static swig_type_info* info = 0;
-  if (!init) {
-    info = SWIG_TypeQuery("_p_char");
-    init = 1;
-  }
-  return info;
-}
-
-
-SWIGINTERNINLINE VALUE 
-SWIG_FromCharPtrAndSize(const char* carray, size_t size)
-{
-  if (carray) {
-    if (size > LONG_MAX) {
-      swig_type_info* pchar_descriptor = SWIG_pchar_descriptor();
-      return pchar_descriptor ? 
-	SWIG_NewPointerObj(const_cast< char * >(carray), pchar_descriptor, 0) : Qnil;
-    } else {
-      return rb_str_new(carray, static_cast< long >(size));
-    }
-  } else {
-    return Qnil;
-  }
-}
-
-
-SWIGINTERNINLINE VALUE 
-SWIG_FromCharPtr(const char *cptr)
-{ 
-  return SWIG_FromCharPtrAndSize(cptr, (cptr ? strlen(cptr) : 0));
-}
-
-
 SWIGINTERNINLINE VALUE
 SWIG_From_unsigned_SS_long  (unsigned long value)
 {
@@ -2552,7 +2516,7 @@ SWIG_ruby_failed(void)
 } 
 
 
-/*@SWIG:/usr/local/Cellar/swig/3.0.11/share/swig/3.0.11/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/usr/local/share/swig/3.0.11/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2DBL(VALUE *args)
 {
   VALUE obj = args[0];
@@ -2591,7 +2555,7 @@ SWIG_From_unsigned_SS_int  (unsigned int value)
 #include <string>
 
 
-/*@SWIG:/usr/local/Cellar/swig/3.0.11/share/swig/3.0.11/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/usr/local/share/swig/3.0.11/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2ULONG(VALUE *args)
 {
   VALUE obj = args[0];
@@ -2669,6 +2633,36 @@ SWIGINTERN std::string Gosu_Color_inspect(Gosu::Color const *self){
             self->alpha(), self->argb() & 0xffffff);
         return buffer;
     }
+
+SWIGINTERN swig_type_info*
+SWIG_pchar_descriptor(void)
+{
+  static int init = 0;
+  static swig_type_info* info = 0;
+  if (!init) {
+    info = SWIG_TypeQuery("_p_char");
+    init = 1;
+  }
+  return info;
+}
+
+
+SWIGINTERNINLINE VALUE 
+SWIG_FromCharPtrAndSize(const char* carray, size_t size)
+{
+  if (carray) {
+    if (size > LONG_MAX) {
+      swig_type_info* pchar_descriptor = SWIG_pchar_descriptor();
+      return pchar_descriptor ? 
+	SWIG_NewPointerObj(const_cast< char * >(carray), pchar_descriptor, 0) : Qnil;
+    } else {
+      return rb_str_new(carray, static_cast< long >(size));
+    }
+  } else {
+    return Qnil;
+  }
+}
+
 
 SWIGINTERNINLINE VALUE
 SWIG_From_std_string  (const std::string& s)
@@ -2759,7 +2753,7 @@ SWIG_AsPtr_std_string (VALUE obj, std::string **val)
 }
 
 
-/*@SWIG:/usr/local/Cellar/swig/3.0.11/share/swig/3.0.11/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
+/*@SWIG:/usr/local/share/swig/3.0.11/ruby/rubyprimtypes.swg,19,%ruby_aux_method@*/
 SWIGINTERN VALUE SWIG_AUX_NUM2LONG(VALUE *args)
 {
   VALUE obj = args[0];
@@ -11216,6 +11210,7 @@ static swig_type_info _swigt__p_Gosu__Window = {"_p_Gosu__Window", "Gosu::Window
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_double = {"_p_double", "Gosu::ZPos *|double *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__arrayT_double_16_t = {"_p_std__arrayT_double_16_t", "std::array< double,16 > *|Gosu::Transform *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_std__string = {"_p_std__string", "std::string *", 0, 0, (void*)0, 0};
 
 static swig_type_info *swig_type_initial[] = {
   &_swigt__p_Gosu__Button,
@@ -11231,6 +11226,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_char,
   &_swigt__p_double,
   &_swigt__p_std__arrayT_double_16_t,
+  &_swigt__p_std__string,
 };
 
 static swig_cast_info _swigc__p_Gosu__Button[] = {  {&_swigt__p_Gosu__Button, 0, 0, 0},{0, 0, 0, 0}};
@@ -11246,6 +11242,7 @@ static swig_cast_info _swigc__p_Gosu__Window[] = {  {&_swigt__p_Gosu__Window, 0,
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_double[] = {  {&_swigt__p_double, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__arrayT_double_16_t[] = {  {&_swigt__p_std__arrayT_double_16_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_std__string[] = {  {&_swigt__p_std__string, 0, 0, 0},{0, 0, 0, 0}};
 
 static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_Gosu__Button,
@@ -11261,6 +11258,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_char,
   _swigc__p_double,
   _swigc__p_std__arrayT_double_16_t,
+  _swigc__p_std__string,
 };
 
 
@@ -11515,11 +11513,11 @@ SWIGEXPORT void Init_gosu(void) {
   }
   
   SWIG_RubyInitializeTrackings();
+  rb_define_const(mGosu, "VERSION", SWIG_From_std_string(static_cast< std::string >(Gosu::VERSION)));
+  rb_define_const(mGosu, "LICENSES", SWIG_From_std_string(static_cast< std::string >(Gosu::LICENSES)));
   rb_define_const(mGosu, "MAJOR_VERSION", SWIG_From_int(static_cast< int >(0)));
   rb_define_const(mGosu, "MINOR_VERSION", SWIG_From_int(static_cast< int >(10)));
   rb_define_const(mGosu, "POINT_VERSION", SWIG_From_int(static_cast< int >(8)));
-  rb_define_const(mGosu, "VERSION", SWIG_FromCharPtr("0.10.8"));
-  rb_define_const(mGosu, "GOSU_COPYRIGHT_NOTICE", SWIG_FromCharPtr("This software uses the following third-party libraries:\n\nGosu, https://www.libgosu.org, MIT License, http://opensource.org/licenses/MIT\nSDL 2, http://www.libsdl.org, MIT License, http://opensource.org/licenses/MIT\nlibsndfile, http://www.mega-nerd.com/libsndfile, GNU LGPL 3, http://www.gnu.org/copyleft/lesser.html\nOpenAL Soft, http://kcat.strangesoft.net/openal.html, GNU LGPL 2, http://www.gnu.org/licenses/old-licenses/lgpl-2.0.html\n"));
   rb_define_module_function(mGosu, "milliseconds", VALUEFUNC(_wrap_milliseconds), -1);
   rb_define_const(mGosu, "M_PI", SWIG_From_double(static_cast< double >(3.14159265358979323846264338327950288)));
   rb_define_module_function(mGosu, "random", VALUEFUNC(_wrap_random), -1);

--- a/src/Version.cpp
+++ b/src/Version.cpp
@@ -1,0 +1,20 @@
+#include <string>
+#include <Gosu/Version.hpp>
+#include <Gosu/Platform.hpp>
+
+namespace Gosu {
+    const std::string VERSION = std::to_string(GOSU_MAJOR_VERSION) + '.' + std::to_string(GOSU_MINOR_VERSION) + '.' + std::to_string(GOSU_POINT_VERSION);
+
+    const std::string LICENSES =
+        "This software uses the following third-party libraries:\n"
+        "\n"
+        "Gosu, https://www.libgosu.org, MIT License, http://opensource.org/licenses/MIT\n"
+        "SDL 2, http://www.libsdl.org, MIT License, http://opensource.org/licenses/MIT\n"
+#if defined(GOSU_IS_WIN) || defined(GOSU_IS_X)
+        "libsndfile, http://www.mega-nerd.com/libsndfile, GNU LGPL 3, http://www.gnu.org/copyleft/lesser.html\n"
+#endif
+#if defined(GOSU_IS_WIN)
+        "OpenAL Soft, http://kcat.strangesoft.net/openal.html, GNU LGPL 2, http://www.gnu.org/licenses/old-licenses/lgpl-2.0.html\n";
+#endif
+    ;
+}

--- a/windows/Gosu.vcxproj
+++ b/windows/Gosu.vcxproj
@@ -188,6 +188,7 @@
     <ClCompile Include="..\src\TimingWin.cpp" />
     <ClCompile Include="..\src\Utility.cpp" />
     <ClCompile Include="..\src\UtilityWin.cpp" />
+    <ClCompile Include="..\src\Version.cpp" />
     <ClCompile Include="..\src\Window.cpp" />
     <ClCompile Include="..\src\WinUtility.cpp" />
     <ClCompile Include="..\src\BlockAllocator.cpp" />

--- a/windows/Gosu.vcxproj.filters
+++ b/windows/Gosu.vcxproj.filters
@@ -48,6 +48,9 @@
     <ClCompile Include="..\src\UtilityWin.cpp">
       <Filter>Implementation</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\Version.cpp">
+      <Filter>Implementation</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\WinUtility.cpp">
       <Filter>Implementation</Filter>
     </ClCompile>


### PR DESCRIPTION
It's a new year and I want to contribute more to the (ruby) community so I choose a (somewhat) random issue I thought wasn't that hard, but in fact I got some (maybe understanding) problems/questions.

I changed the Gosu/Version.hpp to use the constants defined in Gosu/Plattform.hpp to switch the version depending on the platform, but the ruby binding ist generated through swig which interprets the ifdef-else clause based on the platform of the system which calls rake swig. So I actually need to add the ifdef-else clase in the RubyGosu.cxx as well.

Now to the problem - is my understanding of the "problem" correct and if so - how to tell Swig (probably in ruby.i) to preserve the ifdef clause.

The commits in travis and appveyor are atm just for "testing" purposes as I found no real hint how such an change could otherwise be tested in the gosu environment.