### PR TITLE
Add deprecations to Ruby/Gosu (Resolves #367)

### DIFF
--- a/lib/gosu.rb
+++ b/lib/gosu.rb
@@ -17,3 +17,4 @@ require "gosu.#{RbConfig::CONFIG['DLEXT']}"
 
 require "gosu/swig_patches"
 require "gosu/patches"
+require "gosu/compat"

--- a/lib/gosu/compat.rb
+++ b/lib/gosu/compat.rb
@@ -1,0 +1,179 @@
+# This whole file is about backward compatibility
+
+# First - define some methods to tell the world about their old code
+
+module Gosu
+  DEPRECATION_STACKTRACE_LINES = 1
+
+  # Basically copy&paste from Gem but remove the date-part.
+  def self.deprecate(klass, name, repl)
+    klass.class_eval {
+      old = "_deprecated_#{name}"
+      alias_method old, name
+      define_method name do |*args, &block|
+        Gosu.deprecation_message(self, name, repl)
+        send old, *args, &block
+      end
+    }
+  end
+
+  def self.deprecate_const(name, repl)
+    send(:remove_const, name) if const_defined?(name)
+
+    @@_deprecated_constants ||= {}
+    @@_deprecated_constants[name] = repl
+  end
+
+  # The advantage of this approach is that the old Names won't show up in
+  # any Codecompletion (like IRB) or *.constants, so you have to know the
+  # exact old name to acutally use the old const.
+  # However define the value after the first call, to show the warning only once.
+  def self.const_missing(const_name)
+    if @@_deprecated_constants && repl = @@_deprecated_constants[const_name]
+      Gosu.deprecation_message(self, const_name, repl)
+      const_get(repl)
+    else
+      super
+    end
+  end
+
+  def self.deprecation_message(klass_or_full_message, name=nil, repl=nil)
+    @@_deprecations_shown ||= {}
+
+    msg = if klass_or_full_message.is_a?(String) && name.nil? && repl.nil?
+      [ "DEPRECATION WARNING: #{klass_or_full_message},
+        \n#Called from #{caller[1, DEPRECATION_STACKTRACE_LINES]}"
+      ]
+    else
+      # class-method deprecation warnings result in something like this: #<Class:Gosu::Window>::button_id_to_char is deprecated
+      # so remove the instance-inspect stuff to make it look a bit better
+      target = klass_or_full_message.kind_of?(Module) ? "#{klass_or_full_message.to_s.gsub(/#<Class:(.*)>/, '\1')}::" : "#{klass_or_full_message.class}#"
+      [ "DEPRECATION WARNING: #{target}#{name} is deprecated",
+        repl == :none ? " with no replacement." : "; use #{repl} instead.",
+        "\n#{target}#{name} called from #{Gosu.deprecation_caller.join("\n")}",
+      ]
+    end
+    return if @@_deprecations_shown.has_key?(msg[0])
+    @@_deprecations_shown[msg[0]] = true
+
+    warn "#{msg.join}."
+  end
+
+  # this method removes the noise of the caller due to the deprecation methods
+  def self.deprecation_caller
+    caller.delete_if { |trace_line| trace_line =~ /(deprecat|const_missing)/ }
+      .first(DEPRECATION_STACKTRACE_LINES)
+  end
+end
+
+# No need to pass a Window to Image, Sample and Song
+class Gosu::Image
+  alias initialize_without_window initialize
+
+  def initialize(*args)
+    if args[0].is_a? Gosu::Window
+      Gosu.deprecation_message("Passing a Window to Image#initialize has been deprecated in Gosu 0.9 and the arguments have changed a bit as well. Check out https://www.libgosu.org/rdoc/Gosu/Image.html for more information.")
+      if args.size == 7
+        initialize_without_window args[1], :tileable => args[2], :rect => args[3..-1]
+      else
+        initialize_without_window args[1], :tileable => args[2]
+      end
+    else
+      initialize_without_window(*args)
+    end
+  end
+
+  class << self
+    alias from_text_without_window from_text
+  end
+
+  def self.from_text(*args)
+    if args.size == 4
+      Gosu.deprecation_message("Passing a Window to Image.from_text has been deprecated in Gosu 0.9 and the arguments have changed a bit as well. Check out https://www.libgosu.org/rdoc/Gosu/Image.html for more information.")
+      from_text_without_window(args[1], args[3], :font => args[2])
+    elsif args.size == 7
+      Gosu.deprecation_message("Passing a Window to from_text has been deprecated in Gosu 0.9.")
+      from_text_without_window(args[1], args[3], :font => args[2],
+        :spacing => args[4], :width => args[5], :align => args[6])
+    else
+      from_text_without_window(*args)
+    end
+  end
+end
+
+class Gosu::Sample
+  alias initialize_without_window initialize
+
+  def initialize(*args)
+    if args.first.is_a? Gosu::Window
+      args.shift
+      Gosu.deprecation_message("Passing a Window to Sample#initialize has been deprecated in Gosu 0.7.17.")
+    end
+    initialize_without_window(*args)
+  end
+end
+
+class Gosu::Song
+  alias initialize_without_window initialize
+
+  def initialize(*args)
+    if args.first.is_a? Gosu::Window
+      args.shift
+      Gosu.deprecation_message("Passing a Window to Song#initialize has been deprecated in Gosu 0.7.17.")
+    end
+    initialize_without_window(*args)
+  end
+end
+
+# Moved some Window-methods to the Gosu::Module
+class Gosu::Window
+  
+  # Class methods that have been turned into module methods.
+  class << self
+    def button_id_to_char(id)
+      Gosu.button_id_to_char(id)
+    end
+    Gosu.deprecate self, :button_id_to_char, 'Gosu.button_id_to_char'
+
+    def char_to_button_id(ch)
+      Gosu.char_to_button_id(ch)
+    end
+    Gosu.deprecate self, :char_to_button_id, 'Gosu.char_to_button_id'
+  end
+
+  # Instance methods that have been turned into module methods.
+  %w(draw_line draw_triangle draw_quad
+     flush gl clip_to record
+     transform translate rotate scale
+     button_id_to_char char_to_button_id button_down?).each do |method|
+    define_method method.to_sym do |*args, &block|
+      Gosu.send method, *args, &block
+    end
+    Gosu.deprecate self, method, "Gosu.#{method}"
+  end
+end
+
+# Constants
+module Gosu
+  # This was renamed, because it's not actually a "copyright notice" (Wikipedia: https://en.wikipedia.org/wiki/Copyright_notice).
+  deprecate_const :GOSU_COPYRIGHT_NOTICE, :LICENSES
+
+  module Button; end
+
+  # Support for KbLeft instead of KB_LEFT and Gp3Button2 instead of GP_3_BUTTON_2.
+  Gosu.constants.grep(/^KB_|MS_|GP_/).each do |new_name|
+    old_name = case new_name
+    when :KB_ISO then "KbISO"
+    when :KB_NUMPAD_PLUS then "KbNumpadAdd"
+    when :KB_NUMPAD_MINUS then "KbNumpadSubtract"
+    when :KB_EQUALS then "KbEqual"
+    when :KB_LEFT_BRACKET then "KbBracketLeft"
+    when :KB_RIGHT_BRACKET then "KbBracketRight"
+    else new_name.to_s.capitalize.gsub(/_(.)/) { $1.upcase }
+    end
+    deprecate_const old_name.to_sym, new_name
+
+    # Also import old-style constants into Gosu::Button.
+    Gosu::Button.const_set old_name, Gosu.const_get(new_name)
+  end
+end

--- a/lib/gosu/patches.rb
+++ b/lib/gosu/patches.rb
@@ -18,79 +18,6 @@ class ::Numeric
   end
 end
 
-# Backwards compatibility:
-# Support for KbLeft instead of KB_LEFT and Gp3Button2 instead of GP_3_BUTTON_2.
-# Also import old-style constants into Gosu::Button.
-module Gosu::Button; end
-Gosu.constants.grep(/^KB_|MS_|GP_/).each do |c|
-  old_name = case c
-  when :KB_ISO then "KbISO"
-  when :KB_NUMPAD_PLUS then "KbNumpadAdd"
-  when :KB_NUMPAD_MINUS then "KbNumpadSubtract"
-  when :KB_EQUALS then "KbEqual"
-  when :KB_LEFT_BRACKET then "KbBracketLeft"
-  when :KB_RIGHT_BRACKET then "KbBracketRight"
-  else c.to_s.capitalize.gsub(/_(.)/) { $1.upcase }
-  end
-  Gosu.const_set old_name, Gosu.const_get(c)
-  Gosu::Button.const_set old_name, Gosu.const_get(c)
-end
-
-# Backwards compatibility:
-# Passing a Window to initialize and from_text has been deprecated in Gosu 0.9.
-class Gosu::Image
-  alias initialize_without_window initialize
-
-  def initialize(*args)
-    if args[0].is_a? Gosu::Window
-      if args.size == 7
-        initialize_without_window args[1], :tileable => args[2], :rect => args[3..-1]
-      else
-        initialize_without_window args[1], :tileable => args[2]
-      end
-    else
-      initialize_without_window(*args)
-    end
-  end
-
-  class << self
-    alias from_text_without_window from_text
-  end
-
-  def self.from_text(*args)
-    if args.size == 4
-      from_text_without_window(args[1], args[3], :font => args[2])
-    elsif args.size == 7
-      from_text_without_window(args[1], args[3], :font => args[2],
-        :spacing => args[4], :width => args[5], :align => args[6])
-    else
-      from_text_without_window(*args)
-    end
-  end
-end
-
-# Backwards compatibility:
-# Passing a Window to Sample#initialize has been deprecated in Gosu 0.7.17.
-class Gosu::Sample
-  alias initialize_without_window initialize
-
-  def initialize(*args)
-    args.shift if args.first.is_a? Gosu::Window
-    initialize_without_window(*args)
-  end
-end
-
-# Backwards compatibility:
-# Passing a Window to Song#initialize has been deprecated in Gosu 0.7.17.
-class Gosu::Song
-  alias initialize_without_window initialize
-
-  def initialize(*args)
-    args.shift if args.first.is_a? Gosu::Window
-    initialize_without_window(*args)
-  end
-end
-
 # Color constants.
 # This is cleaner than having SWIG define them.
 module Gosu
@@ -119,29 +46,6 @@ module Gosu
 end
 
 class Gosu::Window
-  # Backwards compatibility:
-  # Class methods that have been turned into module methods.
-
-  def self.button_id_to_char(id)
-    Gosu.button_id_to_char(id)
-  end
-
-  def self.char_to_button_id(ch)
-    Gosu.char_to_button_id(ch)
-  end
-
-  # Backwards compatibility:
-  # Instance methods that have been turned into module methods.
-
-  %w(draw_line draw_triangle draw_quad
-     flush gl clip_to record
-     transform translate rotate scale
-     button_id_to_char char_to_button_id button_down?).each do |method|
-    define_method method.to_sym do |*args, &block|
-      Gosu.send method, *args, &block
-    end
-  end
-
   # Call Thread.pass every tick, which may or may not be necessary for friendly co-existence with
   # Ruby's Thread class.
 
@@ -152,10 +56,6 @@ class Gosu::Window
     _tick
   end
 end
-
-# Backwards compatibility:
-# This was renamed, because it's not actually a "copyright notice" (Wikipedia: https://en.wikipedia.org/wiki/Copyright_notice).
-Gosu::GOSU_COPYRIGHT_NOTICE = Gosu::LICENSES
 
 # Release OpenAL resources during Ruby's shutdown, not Gosu's.
 at_exit do

--- a/lib/gosu/swig_patches.rb
+++ b/lib/gosu/swig_patches.rb
@@ -28,7 +28,7 @@ class Gosu::Window
         # Conveniently turn the return value into a boolean result (for needs_cursor? etc).
         defined?(@_exception) ? false : !!send(callback, *args)
       rescue Exception => e
-        # Exit the message loop naturally, then re-throw
+        # Exit the message loop naturally, re-throw
         @_exception = e
         close
         false

--- a/rdoc/gosu.rb
+++ b/rdoc/gosu.rb
@@ -18,10 +18,6 @@ module Gosu
   VERSION = :a_string
 
   ##
-  # @deprecated Use LICENSES instead as it's a more appropriate name
-  GOSU_COPYRIGHT_NOTICE = :a_string
-
-  ##
   # A block of legal copy that your game is obliged to display somewhere.
   LICENSES = :a_string
 

--- a/test/test_constants.rb
+++ b/test/test_constants.rb
@@ -1,3 +1,5 @@
+# Encoding: UTF-8
+
 require "minitest/autorun"
 require "gosu" unless defined? Gosu
 
@@ -16,6 +18,8 @@ class TestConstants < Minitest::Test
     end
 
     # Backward compatibility
-    assert_equal Gosu::LICENSES, Gosu::GOSU_COPYRIGHT_NOTICE
+    assert_output "", /DEPRECATION WARNING: Gosu::GOSU_COPYRIGHT_NOTICE is deprecated; use LICENSES instead./ do
+      assert_equal Gosu::LICENSES, Gosu::GOSU_COPYRIGHT_NOTICE
+    end
   end
 end

--- a/test/test_deprecations.rb
+++ b/test/test_deprecations.rb
@@ -1,0 +1,75 @@
+# Encoding: UTF-8
+
+require "minitest/autorun"
+require "gosu" unless defined? Gosu
+
+class TestDeprecations < Minitest::Test
+  def test_gosu_module_constants
+    # test only a few Button constants as they're automatically generated, so if these works, all other constants should work too
+    assert_output("", /DEPRECATION WARNING: Gosu::Kb0 is deprecated; use KB_0 instead./) { Gosu::Kb0 }
+    assert_output("", /DEPRECATION WARNING: Gosu::KbNumpadSubtract is deprecated; use KB_NUMPAD_MINUS instead./) { Gosu::KbNumpadSubtract }
+    assert_output("", /DEPRECATION WARNING: Gosu::MsLeft is deprecated; use MS_LEFT instead./) { Gosu::MsLeft }
+    assert_output("", /DEPRECATION WARNING: Gosu::GpDown is deprecated; use GP_DOWN instead./) { Gosu::GpDown }
+    assert_output("", /DEPRECATION WARNING: Gosu::Gp0Left is deprecated; use GP_0_LEFT instead./) { Gosu::Gp0Left }
+    assert_output("", /DEPRECATION WARNING: Gosu::Gp1Right is deprecated; use GP_1_RIGHT instead./) { Gosu::Gp1Right }
+    assert_output("", /DEPRECATION WARNING: Gosu::Gp2Up is deprecated; use GP_2_UP instead./) { Gosu::Gp2Up }
+    assert_output("", /DEPRECATION WARNING: Gosu::Gp3Button0 is deprecated; use GP_3_BUTTON_0 instead./) { Gosu::Gp3Button0 }
+  end
+
+  def test_only_warn_once_per_origin
+    assert_output("", /DEPRECATION WARNING/) { single_origin }
+    assert_silent { single_origin }
+  end
+
+  def single_origin
+    Gosu::KbEscape
+    with_gosu_window do |win|
+      win.button_id_to_char(Gosu::KB_A)
+    end
+  end
+
+  def test_window_no_longer_needed
+    with_gosu_window do |win|
+      assert_output("", /DEPRECATION WARNING: Passing a Window to Sample#initialize has been deprecated in Gosu 0.7.17./) do
+        assert_raises(::ArgumentError) { Gosu::Sample.new(win) }
+      end
+
+      assert_output("", /DEPRECATION WARNING: Passing a Window to Song#initialize has been deprecated in Gosu 0.7.17./) do
+        assert_raises(::ArgumentError) { Gosu::Song.new(win) }
+      end
+
+      assert_output("", /DEPRECATION WARNING: Passing a Window to Image#initialize has been deprecated in Gosu 0.9./) do
+        assert_raises(::NoMethodError) { Gosu::Image.new(win) }
+      end
+
+      assert_output("", /DEPRECATION WARNING: Passing a Window to Image.from_text has been deprecated in Gosu 0.9./) do
+        assert_raises(::TypeError) { Gosu::Image.from_text(win,2,3,4) }
+        assert_raises(::TypeError) { Gosu::Image.from_text(win,2,3,4,5,6,7) }
+      end
+    end
+  end
+
+  def test_moved_window_to_gosu_module_methods
+    # Class methods that have been turned into module methods.
+    assert_output("", /DEPRECATION WARNING: Gosu::Window::button_id_to_char is deprecated; use Gosu.button_id_to_char instead./) { Gosu::Window.button_id_to_char(Gosu::KB_A) }
+    assert_output("", /DEPRECATION WARNING: Gosu::Window::char_to_button_id is deprecated; use Gosu.char_to_button_id instead./) { Gosu::Window.char_to_button_id("A") }
+
+    # Instance methods that have been turned into module methods.
+    # test only a few methods as they're automatically generated, so if these works, all other should work as well
+
+    with_gosu_window do |win|
+      %w(draw_line translate char_to_button_id).each do |meth|
+        assert_output("", %r{DEPRECATION WARNING: Gosu::Window##{meth} is deprecated; use Gosu.#{meth} instead.}) do
+          assert_raises(::ArgumentError) { win.send(meth) }
+        end
+      end
+    end
+  end
+
+  # Catch a linux specific error
+  def with_gosu_window
+    yield Gosu::Window.new(10,10)
+  rescue RuntimeError => e
+    raise e unless e.message =~ /Could not initialize SDL Video/
+  end
+end

--- a/test/test_interface.rb
+++ b/test/test_interface.rb
@@ -44,10 +44,13 @@ end
 
 class TestInterface < Minitest::Test
   DOCUMENTED_CONSTANTS = GosuDocs.constants.map { |constant| unpack_range(constant) }.flatten
-  
+
   def test_all_constants_exist
     DOCUMENTED_CONSTANTS.each do |constant|
-      assert Gosu.constants.include?(constant), "Expected constant Gosu::#{constant}"
+      # There should be no deprecated constants in the docs
+      assert_silent do
+        assert Gosu.const_defined?(constant), "Expected constant Gosu::#{constant}"
+      end
     end
   end
   
@@ -69,8 +72,10 @@ class TestInterface < Minitest::Test
   
   def test_no_extra_constants
     Gosu.constants.each do |constant|
-      next if constant =~ /Kb|Gp|Ms/ # backwards compatibility
       next if constant == :Button # backwards compatibility
+      next if constant =~ /Kb|Gp|Ms/ # backwards compatibility
+      next if constant == :GOSU_COPYRIGHT_NOTICE # backwards compatibility
+      next if constant == :DEPRECATION_STACKTRACE_LINES # implementation detail for backwards compatibility
       next if constant == :ImmutableColor # implementation detail
       next if constant == :MAX_TEXTURE_SIZE # not sure if we still need this :/
       


### PR DESCRIPTION
I splitted some parts of `patches.rb` into `compat.rb`. Now patches has all the real "Patch" stuff and compat everything related to deprecations. I also added a test although the test branch isn't merged yet so I temporarily enabled a run of this test file in appveyor and travis in the second commit.

I wasn't sure if the Button constants are meant to be deprecated or just as alternative. At the moment I treat them as deprecated, because they are ruby-like enough :smile: 

EDIT: Why is there no CI run...