### PR TITLE
Resolves #287 - add a SDL_QUIT callback ...

### DIFF
--- a/Gosu/Window.hpp
+++ b/Gosu/Window.hpp
@@ -77,10 +77,9 @@ namespace Gosu
         virtual bool tick();
         
         //! Closes the window if it is currently shown.
-        void close();
-
-        //! Gives the game a chance to say no to being closed. True by default.
-        virtual bool shall_close() const { return true; }
+        //! If you do not want the window to close immediately, you should override this method and
+        //! only call the base implementation (Window::close) when needed.
+        virtual void close();
 
         //! Called every update_interval milliseconds while the window is being shown.
         //! Your application's main game logic goes here.

--- a/Gosu/Window.hpp
+++ b/Gosu/Window.hpp
@@ -79,6 +79,9 @@ namespace Gosu
         //! Closes the window if it is currently shown.
         void close();
 
+        //! Gives the game a chance to say no to being closed. True by default.
+        virtual bool shall_close() const { return true; }
+
         //! Called every update_interval milliseconds while the window is being shown.
         //! Your application's main game logic goes here.
         virtual void update() {}

--- a/examples/Tutorial/Tutorial.cpp
+++ b/examples/Tutorial/Tutorial.cpp
@@ -193,7 +193,7 @@ public:
     void button_down(Gosu::Button button) override
     {
         if (button == Gosu::KB_ESCAPE) {
-           close();
+            close();
         }
         else {
             Window::button_down(button);

--- a/ext/gosu/gosu.i
+++ b/ext/gosu/gosu.i
@@ -919,7 +919,7 @@ namespace Gosu
 %rename("mouse_y=") set_mouse_y;
 %rename("needs_cursor?") needs_cursor;
 %rename("needs_redraw?") needs_redraw;
-%rename("close?") shall_close;
+%rename("close!") force_close;
 %rename("fullscreen?") fullscreen;
 %markfunc Gosu::Window "mark_window";
 %include "../../Gosu/Window.hpp"
@@ -984,6 +984,11 @@ namespace Gosu
     void set_mouse_y(double y)
     {
         $self->input().set_mouse_position($self->input().mouse_x(), y);
+    }
+    
+    void force_close()
+    {
+        $self->Gosu::Window::close();
     }
 };
 

--- a/ext/gosu/gosu.i
+++ b/ext/gosu/gosu.i
@@ -919,6 +919,7 @@ namespace Gosu
 %rename("mouse_y=") set_mouse_y;
 %rename("needs_cursor?") needs_cursor;
 %rename("needs_redraw?") needs_redraw;
+%rename("close?") shall_close;
 %rename("fullscreen?") fullscreen;
 %markfunc Gosu::Window "mark_window";
 %include "../../Gosu/Window.hpp"

--- a/rdoc/gosu.rb
+++ b/rdoc/gosu.rb
@@ -778,10 +778,10 @@ module Gosu
     def tick; end
 
     ##
-    # Tells the window to end the current run loop as soon as possible. Calling this method will not prevent execution of lines after it.
+    # Tells the window to end the current run loop as soon as possible.
     #
     # @return [void]
-    def close; end
+    def close!; end
 
     # @!group Callbacks
 
@@ -814,13 +814,14 @@ module Gosu
     def needs_cursor?; end
 
     ##
-    # Whenever an QUIT event occurs (e.g. by clicking on the X of the Window or calling #close) this method is called first. Return true to
-    # confirm the close-attempt or false to prevent it. Could be used for quit-dialogs like "You haven't save the game, do you really want to
-    # quit?". See https://github.com/gosu/gosu/issues/287#issuecomment-127010001 for more details on this.
+    # This method is called whenever the user tries to close the window, e.g. by clicking the [x]
+    # button in the window's title bar.
+    # If you do not want the window to close immediately, you should override this method and
+    # call the {#close!} when needed.
     #
     # @return [bool]
-    def close?; true; end
-
+    def close; end
+    
     ##
     # This method is called before {#update} if a button is pressed while the window has focus.
     #

--- a/rdoc/gosu.rb
+++ b/rdoc/gosu.rb
@@ -814,6 +814,14 @@ module Gosu
     def needs_cursor?; end
 
     ##
+    # Whenever an QUIT event occurs (e.g. by clicking on the X of the Window or calling #close) this method is called first. Return true to
+    # confirm the close-attempt or false to prevent it. Could be used for quit-dialogs like "You haven't save the game, do you really want to
+    # quit?". See https://github.com/gosu/gosu/issues/287#issuecomment-127010001 for more details on this.
+    #
+    # @return [bool]
+    def close?; true; end
+
+    ##
     # This method is called before {#update} if a button is pressed while the window has focus.
     #
     # By default, this method  will toggle fullscreen mode if the user presses alt+enter (Windows,

--- a/src/RubyGosu.cxx
+++ b/src/RubyGosu.cxx
@@ -3172,6 +3172,9 @@ SWIGINTERN void Gosu_Window_set_mouse_x(Gosu::Window *self,double x){
 SWIGINTERN void Gosu_Window_set_mouse_y(Gosu::Window *self,double y){
         self->input().set_mouse_position(self->input().mouse_x(), y);
     }
+SWIGINTERN void Gosu_Window_force_close(Gosu::Window *self){
+        self->Gosu::Window::close();
+    }
 
     // Also mark the TextInput instance alive when the window is being marked.
     static void mark_window(void* window)
@@ -3252,18 +3255,10 @@ bool SwigDirector_Window::tick() {
 }
 
 
-bool SwigDirector_Window::shall_close() const {
-  bool c_result ;
+void SwigDirector_Window::close() {
   VALUE SWIGUNUSED result;
   
-  result = rb_funcall(swig_get_self(), rb_intern("close?"), 0, NULL);
-  bool swig_val;
-  int swig_res = SWIG_AsVal_bool(result, &swig_val);
-  if (!SWIG_IsOK(swig_res)) {
-    Swig::DirectorTypeMismatchException::raise(SWIG_ErrorType(SWIG_ArgError(swig_res)), "in output value of type '""bool""'");
-  }
-  c_result = static_cast< bool >(swig_val);
-  return (bool) c_result;
+  result = rb_funcall(swig_get_self(), rb_intern("close"), 0, NULL);
 }
 
 
@@ -9198,6 +9193,8 @@ _wrap_Window_close(int argc, VALUE *argv, VALUE self) {
   Gosu::Window *arg1 = (Gosu::Window *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
+  Swig::Director *director = 0;
+  bool upcall = false;
   
   if ((argc < 0) || (argc > 0)) {
     rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
@@ -9207,47 +9204,15 @@ _wrap_Window_close(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "Gosu::Window *","close", 1, self )); 
   }
   arg1 = reinterpret_cast< Gosu::Window * >(argp1);
-  {
-    try {
-      (arg1)->close();
-    }
-    catch (const std::exception& e) {
-      SWIG_exception(SWIG_RuntimeError, e.what());
-    }
-  }
-  return Qnil;
-fail:
-  return Qnil;
-}
-
-
-SWIGINTERN VALUE
-_wrap_Window_closeq___(int argc, VALUE *argv, VALUE self) {
-  Gosu::Window *arg1 = (Gosu::Window *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  Swig::Director *director = 0;
-  bool upcall = false;
-  bool result;
-  VALUE vresult = Qnil;
-  
-  if ((argc < 0) || (argc > 0)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
-  }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_Gosu__Window, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "Gosu::Window const *","shall_close", 1, self )); 
-  }
-  arg1 = reinterpret_cast< Gosu::Window * >(argp1);
   director = dynamic_cast<Swig::Director *>(arg1);
   upcall = (director && (director->swig_get_self() == self));
   try {
     {
       try {
         if (upcall) {
-          result = (bool)((Gosu::Window const *)arg1)->Gosu::Window::shall_close();
+          (arg1)->Gosu::Window::close();
         } else {
-          result = (bool)((Gosu::Window const *)arg1)->shall_close();
+          (arg1)->close();
         }
       }
       catch (const std::exception& e) {
@@ -9258,8 +9223,7 @@ _wrap_Window_closeq___(int argc, VALUE *argv, VALUE self) {
     rb_exc_raise(e.getError());
     SWIG_fail;
   }
-  vresult = SWIG_From_bool(static_cast< bool >(result));
-  return vresult;
+  return Qnil;
 fail:
   return Qnil;
 }
@@ -9955,6 +9919,34 @@ _wrap_Window_mouse_ye___(int argc, VALUE *argv, VALUE self) {
   {
     try {
       Gosu_Window_set_mouse_y(arg1,arg2);
+    }
+    catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  return Qnil;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Window_closeN___(int argc, VALUE *argv, VALUE self) {
+  Gosu::Window *arg1 = (Gosu::Window *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_Gosu__Window, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "Gosu::Window *","force_close", 1, self )); 
+  }
+  arg1 = reinterpret_cast< Gosu::Window * >(argp1);
+  {
+    try {
+      Gosu_Window_force_close(arg1);
     }
     catch (const std::exception& e) {
       SWIG_exception(SWIG_RuntimeError, e.what());
@@ -11985,7 +11977,6 @@ SWIGEXPORT void Init_gosu(void) {
   rb_define_method(SwigClassWindow.klass, "show", VALUEFUNC(_wrap_Window_show), -1);
   rb_define_method(SwigClassWindow.klass, "tick", VALUEFUNC(_wrap_Window_tick), -1);
   rb_define_method(SwigClassWindow.klass, "close", VALUEFUNC(_wrap_Window_close), -1);
-  rb_define_method(SwigClassWindow.klass, "close?", VALUEFUNC(_wrap_Window_closeq___), -1);
   rb_define_method(SwigClassWindow.klass, "update", VALUEFUNC(_wrap_Window_update), -1);
   rb_define_method(SwigClassWindow.klass, "draw", VALUEFUNC(_wrap_Window_draw), -1);
   rb_define_method(SwigClassWindow.klass, "needs_redraw?", VALUEFUNC(_wrap_Window_needs_redrawq___), -1);
@@ -12004,6 +11995,7 @@ SWIGEXPORT void Init_gosu(void) {
   rb_define_method(SwigClassWindow.klass, "set_mouse_position", VALUEFUNC(_wrap_Window_set_mouse_position), -1);
   rb_define_method(SwigClassWindow.klass, "mouse_x=", VALUEFUNC(_wrap_Window_mouse_xe___), -1);
   rb_define_method(SwigClassWindow.klass, "mouse_y=", VALUEFUNC(_wrap_Window_mouse_ye___), -1);
+  rb_define_method(SwigClassWindow.klass, "close!", VALUEFUNC(_wrap_Window_closeN___), -1);
   SwigClassWindow.mark = (void (*)(void *)) mark_window;
   SwigClassWindow.destroy = (void (*)(void *)) free_Gosu_Window;
   SwigClassWindow.trackObjects = 1;

--- a/src/RubyGosu.cxx
+++ b/src/RubyGosu.cxx
@@ -3252,6 +3252,21 @@ bool SwigDirector_Window::tick() {
 }
 
 
+bool SwigDirector_Window::shall_close() const {
+  bool c_result ;
+  VALUE SWIGUNUSED result;
+  
+  result = rb_funcall(swig_get_self(), rb_intern("close?"), 0, NULL);
+  bool swig_val;
+  int swig_res = SWIG_AsVal_bool(result, &swig_val);
+  if (!SWIG_IsOK(swig_res)) {
+    Swig::DirectorTypeMismatchException::raise(SWIG_ErrorType(SWIG_ArgError(swig_res)), "in output value of type '""bool""'");
+  }
+  c_result = static_cast< bool >(swig_val);
+  return (bool) c_result;
+}
+
+
 void SwigDirector_Window::update() {
   VALUE SWIGUNUSED result;
   
@@ -9207,6 +9222,50 @@ fail:
 
 
 SWIGINTERN VALUE
+_wrap_Window_closeq___(int argc, VALUE *argv, VALUE self) {
+  Gosu::Window *arg1 = (Gosu::Window *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  Swig::Director *director = 0;
+  bool upcall = false;
+  bool result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_Gosu__Window, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "Gosu::Window const *","shall_close", 1, self )); 
+  }
+  arg1 = reinterpret_cast< Gosu::Window * >(argp1);
+  director = dynamic_cast<Swig::Director *>(arg1);
+  upcall = (director && (director->swig_get_self() == self));
+  try {
+    {
+      try {
+        if (upcall) {
+          result = (bool)((Gosu::Window const *)arg1)->Gosu::Window::shall_close();
+        } else {
+          result = (bool)((Gosu::Window const *)arg1)->shall_close();
+        }
+      }
+      catch (const std::exception& e) {
+        SWIG_exception(SWIG_RuntimeError, e.what());
+      }
+    }
+  } catch (Swig::DirectorException& e) {
+    rb_exc_raise(e.getError());
+    SWIG_fail;
+  }
+  vresult = SWIG_From_bool(static_cast< bool >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
 _wrap_Window_update(int argc, VALUE *argv, VALUE self) {
   Gosu::Window *arg1 = (Gosu::Window *) 0 ;
   void *argp1 = 0 ;
@@ -11926,6 +11985,7 @@ SWIGEXPORT void Init_gosu(void) {
   rb_define_method(SwigClassWindow.klass, "show", VALUEFUNC(_wrap_Window_show), -1);
   rb_define_method(SwigClassWindow.klass, "tick", VALUEFUNC(_wrap_Window_tick), -1);
   rb_define_method(SwigClassWindow.klass, "close", VALUEFUNC(_wrap_Window_close), -1);
+  rb_define_method(SwigClassWindow.klass, "close?", VALUEFUNC(_wrap_Window_closeq___), -1);
   rb_define_method(SwigClassWindow.klass, "update", VALUEFUNC(_wrap_Window_update), -1);
   rb_define_method(SwigClassWindow.klass, "draw", VALUEFUNC(_wrap_Window_draw), -1);
   rb_define_method(SwigClassWindow.klass, "needs_redraw?", VALUEFUNC(_wrap_Window_needs_redrawq___), -1);

--- a/src/RubyGosu.h
+++ b/src/RubyGosu.h
@@ -32,7 +32,7 @@ public:
     virtual ~SwigDirector_Window();
     virtual void show();
     virtual bool tick();
-    virtual bool shall_close() const;
+    virtual void close();
     virtual void update();
     virtual void draw();
     virtual bool needs_redraw() const;

--- a/src/RubyGosu.h
+++ b/src/RubyGosu.h
@@ -32,6 +32,7 @@ public:
     virtual ~SwigDirector_Window();
     virtual void show();
     virtual bool tick();
+    virtual bool shall_close() const;
     virtual void update();
     virtual void draw();
     virtual bool needs_redraw() const;

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -239,8 +239,10 @@ bool Gosu::Window::tick()
     SDL_Event e;
     while (SDL_PollEvent(&e)) {
         if (e.type == SDL_QUIT) {
-            SDL_HideWindow(shared_window());
-            return false;
+            if (shall_close()) {
+              SDL_HideWindow(shared_window());
+              return false;
+            }
         }
         else {
             input().feed_sdl_event(&e);

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -83,6 +83,12 @@ struct Gosu::Window::Impl
     bool fullscreen;
     double update_interval;
     
+    // A single `bool open` is not good enough to support the tick() method: When close() is called
+    // from outside the window's call graph, the next call to tick() must return false (transition
+    // from CLOSING to CLOSED), but the call after that must return show the window again
+    // (transition from CLOSED to OPEN).
+    enum { CLOSED, OPEN, CLOSING } state = CLOSED;
+    
     std::unique_ptr<Graphics> graphics;
     std::unique_ptr<Input> input;
 };
@@ -93,10 +99,11 @@ Gosu::Window::Window(unsigned width, unsigned height, bool fullscreen, double up
     // Even in fullscreen mode, temporarily show the window in windowed mode to centre it.
     // This ensures that the window will be centred correctly when exiting fullscreen mode.
     // Fixes https://github.com/gosu/gosu/issues/369
+    // (This will implicitly create graphics() and input(), and make the OpenGL context current.)
     resize(width, height, false);
     SDL_SetWindowPosition(shared_window(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 
-    // This will implicitly create graphics() and input(), and make the OpenGL context current.
+    // Really enable fullscreen if desired.
     resize(width, height, fullscreen);
     
     SDL_GL_SetSwapInterval(1);
@@ -104,7 +111,7 @@ Gosu::Window::Window(unsigned width, unsigned height, bool fullscreen, double up
     pimpl->update_interval = update_interval;
     
     input().on_button_down = [this](Button button) { button_down(button); };
-    input().on_button_up = [this](Button button) { button_up(button); };
+    input().on_button_up   = [this](Button button) { button_up(button); };
 }
 
 Gosu::Window::~Window()
@@ -221,12 +228,20 @@ void Gosu::Window::show()
         
         time_before_tick = milliseconds();
     }
+    
+    pimpl->state = Impl::CLOSED;
 }
 
 bool Gosu::Window::tick()
 {
-    if (SDL_GetWindowFlags(shared_window()) & SDL_WINDOW_HIDDEN) {
+    if (pimpl->state == Impl::CLOSING) {
+        pimpl->state = Impl::CLOSED;
+        return false;
+    }
+    
+    if (pimpl->state == Impl::CLOSED) {
         SDL_ShowWindow(shared_window());
+        pimpl->state = Impl::OPEN;
 
         // SDL_GL_GetDrawableSize returns different values before and after showing the window.
         // -> When first showing the window, update the physical size of Graphics (=glViewport).
@@ -239,10 +254,7 @@ bool Gosu::Window::tick()
     SDL_Event e;
     while (SDL_PollEvent(&e)) {
         if (e.type == SDL_QUIT) {
-            if (shall_close()) {
-              SDL_HideWindow(shared_window());
-              return false;
-            }
+            close();
         }
         else {
             input().feed_sdl_event(&e);
@@ -268,14 +280,17 @@ bool Gosu::Window::tick()
         SDL_GL_SwapWindow(shared_window());
     }
     
-    return true;
+    if (pimpl->state == Impl::CLOSING) {
+        pimpl->state = Impl::CLOSED;
+    }
+    
+    return pimpl->state == Impl::OPEN;
 }
 
 void Gosu::Window::close()
 {
-    SDL_Event e;
-    e.type = SDL_QUIT;
-    SDL_PushEvent(&e);
+    pimpl->state = Impl::CLOSING;
+    SDL_HideWindow(shared_window());
 }
 
 void Gosu::Window::button_down(Button button)

--- a/test/test_window.rb
+++ b/test/test_window.rb
@@ -1,0 +1,33 @@
+# Encoding: UTF-8
+
+require "minitest/autorun"
+require "gosu" unless defined? Gosu
+
+class TestWindow < Minitest::Test
+  class CallbackTestWindow < Gosu::Window
+    attr_accessor :stop
+    def initialize
+      super(10,10)
+      @stop = false
+    end
+
+    def close?
+      puts @stop ? 'Ok lets go.' : 'You shall not pass!'
+      @stop
+    end
+  end
+
+  def test_close_callback
+    assert_output /You shall not pass!\nOk lets go./, '' do
+      win = CallbackTestWindow.new
+      Thread.new(win) do
+        sleep 0.5
+        win.close
+        sleep 0.5
+        win.stop = true
+        win.close
+      end
+      win.show
+    end
+  end
+end


### PR DESCRIPTION
... but not with the close! approach as I got a headache thinking about how to make it work. 

So this is only a small change and after struggling with the real code I'm in favor of using the close? (or shall_close?) keyword. For me its similiar to needs_redraw? which context dependent says yes or no.

This breaks no API but triggers __close?__ too, if Window::close is called.

Trying to make close! I got "a ton" of changes which would break the API for the C++ Version and which would have been rather ugly, but I that definitely could be due to my lack of knowledge around the Gosu-Internals / SWIG and C++  which hopefully reduces over time while trying to resolve some open issues. So far I have learned a bit more how certain things work :smile:

The main problems with the close! approach I got in my head were the following: 

At the moment you call close from Ruby which calls close in C++ which registers a QUIT event which eventually will be processed by Window::tick. Now we want to change this behavior, so that Window::tick calls close() when it receives an QUIT event. So wee need a new method in C++ to register an event (e.g. quit). And close has to return a bool so that I can quit the Window::tick loop. And where should I attach close! ? Should it trigger the quit method which would againg trigger close or should it directly close the window by calling SDL_HideWindow but then how to stop the tick loop from executing? Or do we need a new Event like GOSU_QUIT which is set by close which then is processed by the loop.... :confused:
