### PR TITLE
Add deprecations to Ruby/Gosu (Resolves #367, subset of #370)

### DIFF
--- a/lib/gosu.rb
+++ b/lib/gosu.rb
@@ -10,12 +10,12 @@ if RUBY_PLATFORM =~ /mswin$|mingw32|mingw64|win32\-|\-win32/
   # encoding (see #385).
   ENV["PATH"] = "#{binary_path.encode ENV["PATH"].encoding};#{ENV["PATH"]}"
   
-  # Add the correct directory 
-  RUBY_VERSION =~ /(\d+.\d+)/
-  $LOAD_PATH.unshift "#{binary_path}/#{$1}"
+  # Add the correct lib directory for the current version of Ruby (major.minor).
+  $LOAD_PATH.unshift File.join(binary_path, RUBY_VERSION[/^\d+.\d+/])
 end
 
 require "gosu.#{RbConfig::CONFIG["DLEXT"]}"
 
 require "gosu/swig_patches"
 require "gosu/patches"
+require "gosu/compat"

--- a/lib/gosu/compat.rb
+++ b/lib/gosu/compat.rb
@@ -1,0 +1,183 @@
+# This whole file is about backward compatibility.
+
+# Define some helpers to deprecate code.
+module Gosu
+  DEPRECATION_STACKTRACE_LINES = 1
+
+  # Adapted from RubyGems, but without the date part.
+  def self.deprecate(klass, name, repl)
+    klass.class_eval {
+      old = "_deprecated_#{name}"
+      alias_method old, name
+      define_method name do |*args, &block|
+        Gosu.deprecation_message(self, name, repl)
+        send old, *args, &block
+      end
+    }
+  end
+
+  def self.deprecate_const(name, repl)
+    send(:remove_const, name) if const_defined?(name)
+
+    @@_deprecated_constants ||= {}
+    @@_deprecated_constants[name] = repl
+  end
+
+  # Constant deprecation works by undefining the original constant and then re-adding it in
+  # const_missing, so that each deprecation warning is only printed once.
+  def self.const_missing(const_name)
+    if @@_deprecated_constants && repl = @@_deprecated_constants[const_name]
+      Gosu.deprecation_message(self, const_name, repl)
+      const_get(repl)
+    else
+      super
+    end
+  end
+
+  def self.deprecation_message(klass_or_full_message, name=nil, repl=nil)
+    @@_deprecations_shown ||= {}
+
+    msg = if klass_or_full_message.is_a?(String) and name.nil? and repl.nil?
+      [ "DEPRECATION WARNING: #{klass_or_full_message},
+        \n#Called from #{caller[1, DEPRECATION_STACKTRACE_LINES]}"
+      ]
+    else
+      # Class method deprecation warnings result in something like this:
+      # #<Class:Gosu::Window>::button_id_to_char is deprecated
+      # Remove the instance-inspect stuff to make it look a bit better:
+      if klass_or_full_message.kind_of?(Module)
+        target = "#{klass_or_full_message.to_s.gsub(/#<Class:(.*)>/, '\1')}::"
+      else
+        "#{klass_or_full_message.class}#"
+      end
+      [ "DEPRECATION WARNING: #{target}#{name} is deprecated",
+        repl == :none ? " with no replacement." : "; use #{repl} instead.",
+        "\n#{target}#{name} called from #{Gosu.deprecation_caller.join("\n")}",
+      ]
+    end
+    return if @@_deprecations_shown.has_key?(msg[0])
+    @@_deprecations_shown[msg[0]] = true
+
+    warn "#{msg.join}."
+  end
+
+  # This method removes the deprecation methods themselves from the stacktrace.
+  def self.deprecation_caller
+    caller.delete_if { |trace_line| trace_line =~ /(deprecat|const_missing)/ }
+      .first(DEPRECATION_STACKTRACE_LINES)
+  end
+end
+
+# No need to pass a Window to Image.
+class Gosu::Image
+  alias initialize_without_window initialize
+
+  def initialize(*args)
+    if args[0].is_a? Gosu::Window
+      Gosu.deprecation_message("Passing a Window to Image#initialize has been deprecated in Gosu 0.9 and this method now uses an options hash, see https://www.libgosu.org/rdoc/Gosu/Image.html.")
+      if args.size == 7
+        initialize_without_window args[1], :tileable => args[2], :rect => args[3..-1]
+      else
+        initialize_without_window args[1], :tileable => args[2]
+      end
+    else
+      initialize_without_window(*args)
+    end
+  end
+
+  class << self
+    alias from_text_without_window from_text
+  end
+
+  def self.from_text(*args)
+    if args.size == 4
+      Gosu.deprecation_message("Passing a Window to Image.from_text has been deprecated in Gosu 0.9 and this method now uses an options hash, see https://www.libgosu.org/rdoc/Gosu/Image.html.")
+      from_text_without_window(args[1], args[3], :font => args[2])
+    elsif args.size == 7
+      Gosu.deprecation_message("Passing a Window to Image.from_text has been deprecated in Gosu 0.9 and this method now uses an options hash, see https://www.libgosu.org/rdoc/Gosu/Image.html.")
+      from_text_without_window(args[1], args[3], :font => args[2],
+        :spacing => args[4], :width => args[5], :align => args[6])
+    else
+      from_text_without_window(*args)
+    end
+  end
+end
+
+# No need to pass a Window to Sample.
+class Gosu::Sample
+  alias initialize_without_window initialize
+
+  def initialize(*args)
+    if args.first.is_a? Gosu::Window
+      args.shift
+      Gosu.deprecation_message("Passing a Window to Sample#initialize has been deprecated in Gosu 0.7.17.")
+    end
+    initialize_without_window(*args)
+  end
+end
+
+# No need to pass a Window to Song.
+class Gosu::Song
+  alias initialize_without_window initialize
+
+  def initialize(*args)
+    if args.first.is_a? Gosu::Window
+      args.shift
+      Gosu.deprecation_message("Passing a Window to Song#initialize has been deprecated in Gosu 0.7.17.")
+    end
+    initialize_without_window(*args)
+  end
+end
+
+# Moved some Window-methods to the Gosu::Module
+class Gosu::Window
+  # Class methods that have been turned into module methods.
+  class << self
+    def button_id_to_char(id)
+      Gosu.button_id_to_char(id)
+    end
+
+    def char_to_button_id(ch)
+      Gosu.char_to_button_id(ch)
+    end
+  end
+
+  # Instance methods that have been turned into module methods.
+  %w(draw_line draw_triangle draw_quad
+     flush gl clip_to record
+     transform translate rotate scale
+     button_id_to_char char_to_button_id button_down?).each do |method|
+    define_method method.to_sym do |*args, &block|
+      Gosu.send method, *args, &block
+    end
+  end
+end
+
+# Constants
+module Gosu
+  Gosu.deprecate Window, :set_mouse_position, "Window#mouse_x= and Window#mouse_y="
+  Gosu.deprecate Font, :draw_rot, "Font#draw with Gosu.rotate"
+  
+  # This was renamed because it's not actually a "copyright notice".
+  # (https://en.wikipedia.org/wiki/Copyright_notice)
+  deprecate_const :GOSU_COPYRIGHT_NOTICE, :LICENSES
+  
+  module Button; end
+
+  # Support for KbLeft instead of KB_LEFT and Gp3Button2 instead of GP_3_BUTTON_2.
+  Gosu.constants.grep(/^KB_|MS_|GP_/).each do |new_name|
+    old_name = case new_name
+    when :KB_ISO then "KbISO"
+    when :KB_NUMPAD_PLUS then "KbNumpadAdd"
+    when :KB_NUMPAD_MINUS then "KbNumpadSubtract"
+    when :KB_EQUALS then "KbEqual"
+    when :KB_LEFT_BRACKET then "KbBracketLeft"
+    when :KB_RIGHT_BRACKET then "KbBracketRight"
+    else new_name.to_s.capitalize.gsub(/_(.)/) { $1.upcase }
+    end
+    Gosu.const_set old_name, new_name
+
+    # Also import old-style constants into Gosu::Button.
+    Gosu::Button.const_set old_name, Gosu.const_get(new_name)
+  end
+end

--- a/lib/gosu/patches.rb
+++ b/lib/gosu/patches.rb
@@ -18,79 +18,6 @@ class ::Numeric
   end
 end
 
-# Backwards compatibility:
-# Support for KbLeft instead of KB_LEFT and Gp3Button2 instead of GP_3_BUTTON_2.
-# Also import old-style constants into Gosu::Button.
-module Gosu::Button; end
-Gosu.constants.grep(/^KB_|MS_|GP_/).each do |c|
-  old_name = case c
-  when :KB_ISO then "KbISO"
-  when :KB_NUMPAD_PLUS then "KbNumpadAdd"
-  when :KB_NUMPAD_MINUS then "KbNumpadSubtract"
-  when :KB_EQUALS then "KbEqual"
-  when :KB_LEFT_BRACKET then "KbBracketLeft"
-  when :KB_RIGHT_BRACKET then "KbBracketRight"
-  else c.to_s.capitalize.gsub(/_(.)/) { $1.upcase }
-  end
-  Gosu.const_set old_name, Gosu.const_get(c)
-  Gosu::Button.const_set old_name, Gosu.const_get(c)
-end
-
-# Backwards compatibility:
-# Passing a Window to initialize and from_text has been deprecated in Gosu 0.9.
-class Gosu::Image
-  alias initialize_without_window initialize
-
-  def initialize(*args)
-    if args[0].is_a? Gosu::Window
-      if args.size == 7
-        initialize_without_window args[1], :tileable => args[2], :rect => args[3..-1]
-      else
-        initialize_without_window args[1], :tileable => args[2]
-      end
-    else
-      initialize_without_window(*args)
-    end
-  end
-
-  class << self
-    alias from_text_without_window from_text
-  end
-
-  def self.from_text(*args)
-    if args.size == 4
-      from_text_without_window(args[1], args[3], :font => args[2])
-    elsif args.size == 7
-      from_text_without_window(args[1], args[3], :font => args[2],
-        :spacing => args[4], :width => args[5], :align => args[6])
-    else
-      from_text_without_window(*args)
-    end
-  end
-end
-
-# Backwards compatibility:
-# Passing a Window to Sample#initialize has been deprecated in Gosu 0.7.17.
-class Gosu::Sample
-  alias initialize_without_window initialize
-
-  def initialize(*args)
-    args.shift if args.first.is_a? Gosu::Window
-    initialize_without_window(*args)
-  end
-end
-
-# Backwards compatibility:
-# Passing a Window to Song#initialize has been deprecated in Gosu 0.7.17.
-class Gosu::Song
-  alias initialize_without_window initialize
-
-  def initialize(*args)
-    args.shift if args.first.is_a? Gosu::Window
-    initialize_without_window(*args)
-  end
-end
-
 # Color constants.
 # This is cleaner than having SWIG define them.
 module Gosu
@@ -119,29 +46,6 @@ module Gosu
 end
 
 class Gosu::Window
-  # Backwards compatibility:
-  # Class methods that have been turned into module methods.
-
-  def self.button_id_to_char(id)
-    Gosu.button_id_to_char(id)
-  end
-
-  def self.char_to_button_id(ch)
-    Gosu.char_to_button_id(ch)
-  end
-
-  # Backwards compatibility:
-  # Instance methods that have been turned into module methods.
-
-  %w(draw_line draw_triangle draw_quad
-     flush gl clip_to record
-     transform translate rotate scale
-     button_id_to_char char_to_button_id button_down?).each do |method|
-    define_method method.to_sym do |*args, &block|
-      Gosu.send method, *args, &block
-    end
-  end
-
   # Call Thread.pass every tick, which may or may not be necessary for friendly co-existence with
   # Ruby's Thread class.
 
@@ -152,10 +56,6 @@ class Gosu::Window
     _tick
   end
 end
-
-# Backwards compatibility:
-# This was renamed, because it's not actually a "copyright notice" (Wikipedia: https://en.wikipedia.org/wiki/Copyright_notice).
-Gosu::GOSU_COPYRIGHT_NOTICE = Gosu::LICENSES
 
 # Release OpenAL resources during Ruby's shutdown, not Gosu's.
 at_exit do

--- a/lib/gosu/swig_patches.rb
+++ b/lib/gosu/swig_patches.rb
@@ -28,7 +28,7 @@ class Gosu::Window
         # Conveniently turn the return value into a boolean result (for needs_cursor? etc).
         defined?(@_exception) ? false : !!send(callback, *args)
       rescue Exception => e
-        # Exit the message loop naturally, then re-throw
+        # Exit the message loop naturally, then re-throw during the next tick.
         @_exception = e
         close
         false

--- a/rdoc/gosu.rb
+++ b/rdoc/gosu.rb
@@ -18,10 +18,6 @@ module Gosu
   VERSION = :a_string
 
   ##
-  # @deprecated Use LICENSES instead as it's a more appropriate name
-  GOSU_COPYRIGHT_NOTICE = :a_string
-
-  ##
   # A block of legal copy that your game is obliged to display somewhere.
   LICENSES = :a_string
 
@@ -290,13 +286,6 @@ module Gosu
     # @see https://github.com/gosu/gosu/wiki/Basic-Concepts#drawing-with-colours Drawing with colors, explained in the Gosu Wiki
     # @see https://github.com/gosu/gosu/wiki/Basic-Concepts#z-ordering Z-ordering explained in the Gosu Wiki
     def draw_rel(text, x, y, z, rel_x, rel_y, scale_x=1, scale_y=1, color=0xff_ffffff, mode=:default); end
-
-    ##
-    # @deprecated Use {#draw} in conjunction with {Gosu.rotate} instead.
-    #
-    # @see #draw
-    # @see Gosu::Window#rotate
-    def draw_rot(text, x, y, z, angle, scale_x=1, scale_y=1, color=0xff_ffffff, mode=:default); end
 
     # @!endgroup
 
@@ -848,10 +837,6 @@ module Gosu
     def button_up(id); end
 
     # @!endgroup
-
-    ##
-    # @deprecated Use {#mouse_x=} and {#mouse_y=} instead.
-    def set_mouse_position(x, y); end
   end
 
   ##

--- a/test/test_constants.rb
+++ b/test/test_constants.rb
@@ -14,8 +14,5 @@ class TestConstants < Minitest::Test
       assert_match(/libsndfile/, Gosu::LICENSES)
       assert_match(/OpenAL/, Gosu::LICENSES) if RUBY_PLATFORM =~ /win/
     end
-
-    # Backward compatibility
-    assert_equal Gosu::LICENSES, Gosu::GOSU_COPYRIGHT_NOTICE
   end
 end

--- a/test/test_deprecations.rb
+++ b/test/test_deprecations.rb
@@ -1,0 +1,41 @@
+# Encoding: UTF-8
+require_relative 'test_helper'
+
+class TestDeprecations < Minitest::Test
+  @@win = Gosu::Window.new(100, 100)
+  
+  def test_gosu_module_constants
+    # Backward compatibility
+    assert_output "", /DEPRECATION WARNING: Gosu::GOSU_COPYRIGHT_NOTICE is deprecated; use LICENSES instead./ do
+      assert_equal Gosu::LICENSES, Gosu::GOSU_COPYRIGHT_NOTICE
+    end
+  end
+
+  def test_only_warn_once_per_origin
+    assert_output("", /DEPRECATION WARNING/) { single_origin }
+    assert_silent { single_origin }
+  end
+
+  def single_origin
+    @@win.set_mouse_position(1, 2)
+  end
+  
+  def test_window_no_longer_needed
+    assert_output("", /DEPRECATION WARNING: Passing a Window to Sample#initialize has been deprecated in Gosu 0.7.17./) do
+      assert_raises(::ArgumentError) { Gosu::Sample.new(@@win) }
+    end
+
+    assert_output("", /DEPRECATION WARNING: Passing a Window to Song#initialize has been deprecated in Gosu 0.7.17./) do
+      assert_raises(::ArgumentError) { Gosu::Song.new(@@win) }
+    end
+
+    assert_output("", /DEPRECATION WARNING: Passing a Window to Image#initialize has been deprecated in Gosu 0.9./) do
+      assert_raises(::NoMethodError) { Gosu::Image.new(@@win) }
+    end
+
+    assert_output("", /DEPRECATION WARNING: Passing a Window to Image.from_text has been deprecated in Gosu 0.9./) do
+      assert_raises(::TypeError) { Gosu::Image.from_text(@@win, 2, 3, 4) }
+      assert_raises(::TypeError) { Gosu::Image.from_text(@@win, 2, 3, 4, 5, 6, 7) }
+    end
+  end
+end

--- a/test/test_interface.rb
+++ b/test/test_interface.rb
@@ -42,10 +42,13 @@ end
 
 class TestInterface < Minitest::Test
   DOCUMENTED_CONSTANTS = GosuDocs.constants.map { |constant| unpack_range(constant) }.flatten
-  
+
   def test_all_constants_exist
     DOCUMENTED_CONSTANTS.each do |constant|
-      assert Gosu.constants.include?(constant), "Expected constant Gosu::#{constant}"
+      # There should be no deprecated constants in the docs
+      assert_silent do
+        assert Gosu.const_defined?(constant), "Expected constant Gosu::#{constant}"
+      end
     end
   end
   
@@ -67,8 +70,10 @@ class TestInterface < Minitest::Test
   
   def test_no_extra_constants
     Gosu.constants.each do |constant|
-      next if constant =~ /Kb|Gp|Ms/ # backwards compatibility
       next if constant == :Button # backwards compatibility
+      next if constant =~ /Kb|Gp|Ms/ # backwards compatibility
+      next if constant == :GOSU_COPYRIGHT_NOTICE # backwards compatibility
+      next if constant == :DEPRECATION_STACKTRACE_LINES # implementation detail for backwards compatibility
       next if constant == :ImmutableColor # implementation detail
       next if constant == :MAX_TEXTURE_SIZE # not sure if we still need this :/
       


### PR DESCRIPTION
I still have no idea how to safely deprecate constants and methods that have moved from one scope to another. This PR is a subset #370 that focuses on low-hanging fruit:

- Deprecate the Window constructors, this alone should be a good move for the Gosu ecosystem 👍 
- Deprecate `Window#set_mouse_position` and `Font#draw_rot`, which are always and clearly deprecated. (This is also a good time to remove them from rdoc.)
- Deprecate `Gosu::GOSU_COPYRIGHT_NOTICE` because I really want to deprecate at least one constant, and I (sadly...) doubt many people use this one, especially together with `include Gosu` - so this should be safe enough.