### PR TITLE
Experimental feature: add a simple MessageBox

### DIFF
--- a/Gosu/Window.hpp
+++ b/Gosu/Window.hpp
@@ -31,6 +31,8 @@ namespace Gosu
     //! Returns the maximum height (in 'points') that is available for a non-fullscreen Window.
     //! All windows larger than this size will automatically be shrunk to fit.
     unsigned available_height();
+
+    int simple_dialog(std::string caption, std::string message);
     
     //! Convenient all-in-one class that serves as the foundation of a standard Gosu application.
     //! Manages initialization of all of Gosu's core components and provides timing functionality.

--- a/rdoc/gosu.rb
+++ b/rdoc/gosu.rb
@@ -1209,6 +1209,17 @@ module Gosu
     #
     # @return [String] the user's preferred language.
     def language(); end
+
+    ##
+    # EXPERIMENTAL - MAY DISAPPEAR WITHOUT WARNING.
+    #
+    # Shows an simple dialog box with just the provided message and an OK-Button. The look is system-dependent and can not be influenced.
+    #
+    # @param caption [String]
+    # @param message [String]
+    #
+    def simple_dialog(caption, message)
+    end
   end
 end
 

--- a/src/RubyGosu.cxx
+++ b/src/RubyGosu.cxx
@@ -8777,6 +8777,49 @@ fail:
 }
 
 
+SWIGINTERN VALUE
+_wrap_simple_dialog(int argc, VALUE *argv, VALUE self) {
+  std::string arg1 ;
+  std::string arg2 ;
+  int result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 2) || (argc > 2)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
+  }
+  {
+    std::string *ptr = (std::string *)0;
+    int res = SWIG_AsPtr_std_string(argv[0], &ptr);
+    if (!SWIG_IsOK(res) || !ptr) {
+      SWIG_exception_fail(SWIG_ArgError((ptr ? res : SWIG_TypeError)), Ruby_Format_TypeError( "", "std::string","Gosu::simple_dialog", 1, argv[0] )); 
+    }
+    arg1 = *ptr;
+    if (SWIG_IsNewObj(res)) delete ptr;
+  }
+  {
+    std::string *ptr = (std::string *)0;
+    int res = SWIG_AsPtr_std_string(argv[1], &ptr);
+    if (!SWIG_IsOK(res) || !ptr) {
+      SWIG_exception_fail(SWIG_ArgError((ptr ? res : SWIG_TypeError)), Ruby_Format_TypeError( "", "std::string","Gosu::simple_dialog", 2, argv[1] )); 
+    }
+    arg2 = *ptr;
+    if (SWIG_IsNewObj(res)) delete ptr;
+  }
+  {
+    try {
+      result = (int)Gosu::simple_dialog(arg1,arg2);
+    }
+    catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  vresult = SWIG_From_int(static_cast< int >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
 static swig_class SwigClassWindow;
 
 SWIGINTERN VALUE
@@ -11961,6 +12004,7 @@ SWIGEXPORT void Init_gosu(void) {
   rb_define_module_function(mGosu, "screen_height", VALUEFUNC(_wrap_screen_height), -1);
   rb_define_module_function(mGosu, "available_width", VALUEFUNC(_wrap_available_width), -1);
   rb_define_module_function(mGosu, "available_height", VALUEFUNC(_wrap_available_height), -1);
+  rb_define_module_function(mGosu, "simple_dialog", VALUEFUNC(_wrap_simple_dialog), -1);
   rb_define_module_function(mGosu, "disown_Window", VALUEFUNC(_wrap_disown_Window), -1);
   
   SwigClassWindow.klass = rb_define_class_under(mGosu, "Window", rb_cObject);

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -76,6 +76,12 @@ namespace Gosu
         SDL_DestroyWindow(shared_window());
         SDL_QuitSubSystem(SDL_INIT_VIDEO);
     }
+
+
+    int simple_dialog(std::string caption, std::string message)
+    {
+        return SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_INFORMATION, caption.c_str(), message.c_str(), NULL);
+    }
 }
 
 struct Gosu::Window::Impl


### PR DESCRIPTION
Despite my comment to solve existing issues first I wanted to open this PR as it is in my pipeline for too long and it basically is just one line of code to call an dialog via SDL...

**Why?**
I saw this while working on the Drag&Drop stuff in its example and thought thats pretty simple and might have some use cases. For example one could show the information provided by Gosu::LICENSE with a simple call of

```ruby
Gosu.simple_dialog("About", Gosu::LICENSES)
```

**Todo**
If this is an accepted feature we might move it in a seperate file. To be hones I tried it forever but just couldn't make it work .... I'm just not into the whole C(++) stuff with headers and includes.