### PR TITLE
Add Window#background_color

### DIFF
--- a/Gosu/Graphics.hpp
+++ b/Gosu/Graphics.hpp
@@ -39,7 +39,7 @@ namespace Gosu
 
         //! Prepares the graphics object for drawing and then runs the rendering code in f.
         //! Nothing must be drawn outside of frame() and record().
-        void frame(const std::function<void ()>& f);
+        void frame(Gosu::Color clear_with_color, const std::function<void ()>& f);
         
         //! Flushes the Z queue to the screen and starts a new one.
         //! This can be useful to separate the Z queues of two parts of the game, e.g. the two

--- a/Gosu/Window.hpp
+++ b/Gosu/Window.hpp
@@ -121,6 +121,9 @@ namespace Gosu
         //! \param path The filename of the dropped file. When multiple files are dropped, this
         //! method will be called several times.
         virtual void drop(const std::string& filename) {}
+
+        //! Sets the background_color of the window
+        virtual Gosu::Color background_color() const { return Gosu::Color::RED; }
         
         // Ignore when SWIG is wrapping this class for Ruby/Gosu.
         #ifndef SWIG

--- a/rdoc/gosu.rb
+++ b/rdoc/gosu.rb
@@ -808,6 +808,12 @@ module Gosu
     def needs_cursor?; end
 
     ##
+    # This method can be overriden to set the default window background color. Default is Gosu::Color::BLACK
+    #
+    # @return [Gosu::Color]
+    def background_color; end
+
+    ##
     # This method is called whenever the user tries to close the window, e.g. by clicking the [x]
     # button in the window's title bar.
     # If you do not want the window to close immediately, you should override this method and

--- a/src/Graphics.cpp
+++ b/src/Graphics.cpp
@@ -141,7 +141,7 @@ void Gosu::Graphics::set_resolution(unsigned virtual_width, unsigned virtual_hei
     pimpl->update_base_transform();
 }
 
-void Gosu::Graphics::frame(const std::function<void ()>& f)
+void Gosu::Graphics::frame(Gosu::Color clear_with_color, const std::function<void ()>& f)
 {
     if (current_graphics_pointer != nullptr) {
         throw std::logic_error("Cannot nest calls to Gosu::Graphics::begin()");
@@ -164,7 +164,8 @@ void Gosu::Graphics::frame(const std::function<void ()>& f)
     
     queues.back().set_base_transform(pimpl->base_transform);
     
-    glClearColor(0, 0, 0, 1);
+    glClearColor(clear_with_color.red() / 255.f, clear_with_color.green() / 255.f,
+        clear_with_color.blue() / 255.f, clear_with_color.alpha() / 255.f);
     glClear(GL_COLOR_BUFFER_BIT);
     
     current_graphics_pointer = this;

--- a/src/RubyGosu.cxx
+++ b/src/RubyGosu.cxx
@@ -3339,6 +3339,22 @@ void SwigDirector_Window::drop(std::string const &filename) {
 }
 
 
+Gosu::Color SwigDirector_Window::background_color() const {
+  Gosu::Color c_result ;
+  VALUE SWIGUNUSED result;
+  void *swig_argp ;
+  int swig_res = 0 ;
+  
+  result = rb_funcall(swig_get_self(), rb_intern("background_color"), 0, NULL);
+  swig_res = SWIG_ConvertPtr(result,&swig_argp,SWIGTYPE_p_Gosu__Color,  0 );
+  if (!SWIG_IsOK(swig_res)) {
+    Swig::DirectorTypeMismatchException::raise(SWIG_ErrorType(SWIG_ArgError(swig_res)), "in output value of type '""Gosu::Color""'");
+  }
+  c_result = *(reinterpret_cast< Gosu::Color * >(swig_argp));
+  return (Gosu::Color) c_result;
+}
+
+
 SWIGINTERN VALUE
 _wrap_milliseconds(int argc, VALUE *argv, VALUE self) {
   unsigned long result;
@@ -9625,6 +9641,50 @@ fail:
 
 
 SWIGINTERN VALUE
+_wrap_Window_background_color(int argc, VALUE *argv, VALUE self) {
+  Gosu::Window *arg1 = (Gosu::Window *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  Swig::Director *director = 0;
+  bool upcall = false;
+  Gosu::Color result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_Gosu__Window, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "Gosu::Window const *","background_color", 1, self )); 
+  }
+  arg1 = reinterpret_cast< Gosu::Window * >(argp1);
+  director = dynamic_cast<Swig::Director *>(arg1);
+  upcall = (director && (director->swig_get_self() == self));
+  try {
+    {
+      try {
+        if (upcall) {
+          result = ((Gosu::Window const *)arg1)->Gosu::Window::background_color();
+        } else {
+          result = ((Gosu::Window const *)arg1)->background_color();
+        }
+      }
+      catch (const std::exception& e) {
+        SWIG_exception(SWIG_RuntimeError, e.what());
+      }
+    }
+  } catch (Swig::DirectorException& e) {
+    rb_exc_raise(e.getError());
+    SWIG_fail;
+  }
+  vresult = SWIG_NewPointerObj((new Gosu::Color(static_cast< const Gosu::Color& >(result))), SWIGTYPE_p_Gosu__Color, SWIG_POINTER_OWN |  0 );
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
 _wrap_Window_widthe___(int argc, VALUE *argv, VALUE self) {
   Gosu::Window *arg1 = (Gosu::Window *) 0 ;
   unsigned int arg2 ;
@@ -12039,6 +12099,7 @@ SWIGEXPORT void Init_gosu(void) {
   rb_define_method(SwigClassWindow.klass, "button_down", VALUEFUNC(_wrap_Window_button_down), -1);
   rb_define_method(SwigClassWindow.klass, "button_up", VALUEFUNC(_wrap_Window_button_up), -1);
   rb_define_method(SwigClassWindow.klass, "drop", VALUEFUNC(_wrap_Window_drop), -1);
+  rb_define_method(SwigClassWindow.klass, "background_color", VALUEFUNC(_wrap_Window_background_color), -1);
   rb_define_method(SwigClassWindow.klass, "width=", VALUEFUNC(_wrap_Window_widthe___), -1);
   rb_define_method(SwigClassWindow.klass, "height=", VALUEFUNC(_wrap_Window_heighte___), -1);
   rb_define_method(SwigClassWindow.klass, "fullscreen=", VALUEFUNC(_wrap_Window_fullscreene___), -1);

--- a/src/RubyGosu.h
+++ b/src/RubyGosu.h
@@ -42,6 +42,7 @@ public:
     virtual void button_down(Gosu::Button arg0);
     virtual void button_up(Gosu::Button arg0);
     virtual void drop(std::string const &filename);
+    virtual Gosu::Color background_color() const;
 };
 
 

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -283,7 +283,7 @@ bool Gosu::Window::tick()
     
     if (needs_redraw()) {
         ensure_current_context();
-        graphics().frame([&] {
+        graphics().frame(background_color(), [&] {
             draw();
             FPS::register_frame();
         });

--- a/test/test_window.rb
+++ b/test/test_window.rb
@@ -63,9 +63,35 @@ class TestWindow < Minitest::Test
       end
     end
   end
+
   def test_drag_and_drop
     interactive_gui("Drop any number of files into the window. Do all filenames appear?") do
       DropWindow.new
+    end
+  end
+
+  class ColorChanger < Gosu::Window
+    def initialize
+      super(100, 100)
+      @colors = [Gosu::Color::BLACK, Gosu::Color::WHITE, Gosu::Color::RED, Gosu::Color::BLUE]
+    end
+
+    def update
+      @now ||= Gosu.milliseconds
+      if Gosu.milliseconds - 1000 > @now
+        @colors.rotate!
+        @now = Gosu.milliseconds
+      end
+    end
+
+    def background_color
+      @colors.first
+    end
+  end
+
+  def test_background_color_change
+    interactive_gui("Does the color of the background change over timer?") do
+      ColorChanger.new
     end
   end
 end


### PR DESCRIPTION
While I looked through the code to remember how the rendering stuff works to figure out if [this](https://wiki.delphigl.com/index.php/Screenshot) would work as an easy screenshot command #317 I remembered an old wish of mine to change the window background color. And there right in the code was already a _clear_with_color_ variable - at least until I pulled the latest master. So this PR reverts some of the latest changes and provide a function to actually manipulate the _clear_with_color_-value.

I guess the rest is self-explaining.