### PR TITLE
[WIP] Add Song#finished callback - Resolves #188

### DIFF
--- a/Gosu/Audio.hpp
+++ b/Gosu/Audio.hpp
@@ -133,6 +133,9 @@ namespace Gosu
         //! volume).
         void set_volume(double volume);
         
+        //! Called when the song finished (doesn't get fired on pause/stop)
+        virtual void finished();
+
         //! Called every tick by Window for management purposes.
         static void update();
     };

--- a/Gosu/Audio.hpp
+++ b/Gosu/Audio.hpp
@@ -134,7 +134,7 @@ namespace Gosu
         void set_volume(double volume);
         
         //! Called when the song finished (doesn't get fired on pause/stop)
-        virtual void finished();
+        virtual void finished() {}
 
         //! Called every tick by Window for management purposes.
         static void update();

--- a/lib/gosu/patches.rb
+++ b/lib/gosu/patches.rb
@@ -57,6 +57,19 @@ class Gosu::Window
   end
 end
 
+class Gosu::Song
+  alias _initialize initialize
+
+  def initialize(filename, &block)
+    _initialize(filename)
+    @finished_callback = block
+  end
+
+  def finished
+    @finished_callback.call if @finished_callback
+  end
+end
+
 # Release OpenAL resources during Ruby's shutdown, not Gosu's.
 at_exit do
   begin

--- a/rdoc/gosu.rb
+++ b/rdoc/gosu.rb
@@ -640,6 +640,12 @@ module Gosu
     ##
     # @return [true, false] whether the song is playing.
     def playing?; end
+
+    ##
+    # Called when the song finished (doesn't get fired on pause/stop)
+    #
+    # @return [void]
+    def finished; end
   end
 
   ##

--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -387,7 +387,9 @@ public:
                 play(true);
             }
             else {
-                // Let the world know we're finished.
+                // Let the world know we're finished by firing an "callback" as requested in https://github.com/gosu/gosu/issues/188
+                // OpenAL does not provide a true callback, so this is as close as we can get.
+                finished();
                 cur_song = nullptr;
             }
         }

--- a/src/RubyGosu.cxx
+++ b/src/RubyGosu.cxx
@@ -8377,6 +8377,34 @@ fail:
 
 
 SWIGINTERN VALUE
+_wrap_Song_finished(int argc, VALUE *argv, VALUE self) {
+  Gosu::Song *arg1 = (Gosu::Song *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_Gosu__Song, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "Gosu::Song *","finished", 1, self )); 
+  }
+  arg1 = reinterpret_cast< Gosu::Song * >(argp1);
+  {
+    try {
+      (arg1)->finished();
+    }
+    catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  return Qnil;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
 _wrap_Song_update(int argc, VALUE *argv, VALUE self) {
   if ((argc < 0) || (argc > 0)) {
     rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
@@ -11820,6 +11848,7 @@ SWIGEXPORT void Init_gosu(void) {
   rb_define_method(SwigClassSong.klass, "playing?", VALUEFUNC(_wrap_Song_playingq___), -1);
   rb_define_method(SwigClassSong.klass, "volume", VALUEFUNC(_wrap_Song_volume), -1);
   rb_define_method(SwigClassSong.klass, "volume=", VALUEFUNC(_wrap_Song_volumee___), -1);
+  rb_define_method(SwigClassSong.klass, "finished", VALUEFUNC(_wrap_Song_finished), -1);
   rb_define_singleton_method(SwigClassSong.klass, "update", VALUEFUNC(_wrap_Song_update), -1);
   SwigClassSong.mark = 0;
   SwigClassSong.destroy = (void (*)(void *)) free_Gosu_Song;

--- a/test/test_audio.rb
+++ b/test/test_audio.rb
@@ -114,4 +114,26 @@ class TestAudio < Minitest::Test
     
     assert_nil Gosu::Song.current_song
   end
+
+  def test_song_finished_callback
+    skip_on_appveyor
+
+    win = SongTestWindow.new
+    assert_nil Gosu::Song.current_song
+
+    song1 = Gosu::Song.new(media_path("0614.ogg"))
+    song2 = Gosu::Song.new(media_path("0830.ogg"))
+
+    song1.play(false) { song2.play }
+    assert_equal song1, Gosu::Song.current_song
+
+    assert song1.playing?
+    refute song2.playing?
+
+    (20 * 1000/win.update_interval).ceil.times{ win.tick }
+
+    refute song1.playing?
+    assert song2.playing?
+    assert_equal song2, Gosu::Song.current_song
+  end
 end


### PR DESCRIPTION
Didn't work at the moment because I got some problems with SWIG (again). I tried to remember what I did in the Window#drop callback but couldn't. Swig doesn't register the finished with an upcall wrapper so the overloaded ruby function never is called. Any ideas?

Some general thoughts:

- I added it only to song because there you basically already checked for finished and I can't see any use-case in a Sample right now.
- Don't know lambdas good enough - do you think providing an constructor like Song(filename, callback-lamdba) would be helpful for the C++ users or would they instinctively override finished directly?
- We could theoretically remove the looping logic and define it as finished callback instead, as its basically the same idea: Play a / the same song as soon as the old one is finished.

