### PR TITLE
Add TextInput implementation for iOS/UIKit

### DIFF
--- a/Gosu.podspec
+++ b/Gosu.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.subspec "Gosu" do |ss|
     ss.dependency "Gosu/C"
     ss.osx.deployment_target = "10.9"
-    ss.ios.deployment_target = "5.1.1"
+    ss.ios.deployment_target = "8.0"
     
     # Ignore Gosu using deprecated Gosu APIs internally.
     # Compile all source files as Objective-C++ so we can use ObjC frameworks where necessary.
@@ -46,7 +46,7 @@ Pod::Spec.new do |s|
   s.subspec "GosuAppDelegateMain" do |ss|
     ss.dependency "Gosu/Gosu"
     ss.source_files = "src/GosuAppDelegate.mm"
-    ss.platform = :ios, "5.1.1"
+    ss.platform = :ios, "8.0"
   end
 
   s.default_subspec = "Gosu"

--- a/Gosu/Fwd.hpp
+++ b/Gosu/Fwd.hpp
@@ -9,6 +9,7 @@ namespace Gosu
     class Bitmap;
     class Buffer;
     class Button;
+    class Channel;
     class Color;
     class File;
     class Font;
@@ -21,7 +22,6 @@ namespace Gosu
     class Sample;
     class Song;
     class TextInput;
-    class Timer;
     class Window;
     class Writer;
 }

--- a/Gosu/Input.hpp
+++ b/Gosu/Input.hpp
@@ -59,7 +59,7 @@ namespace Gosu
     public:
     #ifdef GOSU_IS_IPHONE
         Input(void* view, float update_interval);
-        void feed_touch_event(int type, void* touches);
+        void feed_touch_event(std::function<void (Touch)>& callback, void* touches);
     #else
         Input(void* window);
         bool feed_sdl_event(void* event);

--- a/Gosu/TextInput.hpp
+++ b/Gosu/TextInput.hpp
@@ -49,8 +49,10 @@ namespace Gosu
         //! Sets the start of the selection as returned by selection_start.
         void set_selection_start(unsigned pos);
         
+#ifndef GOSU_IS_IPHONE
         // Platform-specific communication with Gosu::Input.
         bool feed_sdl_event(void* event);
+#endif
 
         //! Overridable filter that is applied to all new text that is entered.
         //! Allows for context-sensitive filtering/extending/... of new characters.

--- a/Gosu/TextInput.hpp
+++ b/Gosu/TextInput.hpp
@@ -61,5 +61,15 @@ namespace Gosu
         {
             return text;
         }
+        
+        //! Replaces the current selection (if any) and inserts the given string at the current
+        //! caret position.
+        void insert_text(std::string text);
+        
+        //! Deletes the current selection, if any, or the next character.
+        void delete_forward();
+        
+        //! Deletes the current selection, if any, or the previous character.
+        void delete_backward();
     };
 }

--- a/Gosu/Window.hpp
+++ b/Gosu/Window.hpp
@@ -118,7 +118,7 @@ namespace Gosu
         virtual void button_up(Gosu::Button) {}
 
         //! Called when a file is dropped onto the window.
-        //! \param path The filename of the dropped file. When multiple files are dropped, this
+        //! \param filename The filename of the dropped file. When multiple files are dropped, this
         //! method will be called several times.
         virtual void drop(const std::string& filename) {}
 
@@ -143,7 +143,7 @@ namespace Gosu
         #endif
         
         #ifdef GOSU_IS_IPHONE
-        void* UIWindow() const;
+        void* uikit_window() const;
         #endif
     };
 }

--- a/examples/TextInput/CMakeLists.txt
+++ b/examples/TextInput/CMakeLists.txt
@@ -31,5 +31,3 @@ endif()
 find_package(Gosu REQUIRED development)
 include_directories(${GOSU_INCLUDE_DIRS})
 target_link_libraries(TextInputExample ${GOSU_LIBRARIES})
-
-

--- a/examples/TextInput/TextInput.cpp
+++ b/examples/TextInput/TextInput.cpp
@@ -30,7 +30,7 @@ class TextField : public Gosu::TextInput
     double x, y;
     
 public:
-    // Some ARGB constants that define our appearance.
+    // Some ARGB constants that define the appearance of text fields.
     static const unsigned long INACTIVE_COLOR  = 0xcc666666;
     static const unsigned long ACTIVE_COLOR    = 0xccff6666;
     static const unsigned long SELECTION_COLOR = 0xcc0000ff;
@@ -66,27 +66,21 @@ public:
             background_color = ACTIVE_COLOR;
         }
         
-        Gosu::Graphics::draw_quad(x - PADDING,           y - PADDING,            background_color,
-                                  x + width() + PADDING, y - PADDING,            background_color,
-                                  x - PADDING,           y + height() + PADDING, background_color,
-                                  x + width() + PADDING, y + height() + PADDING, background_color,
-                                  0);
+        Gosu::Graphics::draw_rect(x - PADDING, y - PADDING,
+                                  width() + 2 * PADDING, height + 2 * PADDING,
+                                  background_color, 0);
         
         // Calculate the position of the caret and the selection start.
         double pos_x = x + font.text_width(text().substr(0, caret_pos()));
         double sel_x = x + font.text_width(text().substr(0, selection_start()));
         
         // Draw the selection background, if any; if not, sel_x and pos_x will be
-        // the same value, making this quad empty.
-        Gosu::Graphics::draw_quad(sel_x, y,            SELECTION_COLOR,
-                                  pos_x, y,            SELECTION_COLOR,
-                                  sel_x, y + height(), SELECTION_COLOR,
-                                  pos_x, y + height(), SELECTION_COLOR, 0);
+        // the same value, making this rect empty and invisible.
+        Gosu::Graphics::draw_rect(sel_x, y, pos_x - sel_y, height(), SELECTION_COLOR, 0);
 
-        // Draw the caret; again, only if this is the currently selected field.
+        // Draw the caret if this is the currently selected field.
         if (window.input().text_input() == this) {
-            Gosu::Graphics::draw_line(pos_x, y,            CARET_COLOR,
-                                      pos_x, y + height(), CARET_COLOR, 0);
+            Gosu::Graphics::draw_rect(pos_x, y, 1, height(), CARET_COLOR, 0);
         }
         
         // Finally, draw the text itself!
@@ -112,7 +106,7 @@ public:
     }
 };
 
-// Helper to get the size static arrays.
+// Helper to get the size of static arrays.
 template<typename T, std::size_t Length>
 std::size_t lengthof(const T(&) [Length])
 {
@@ -151,8 +145,8 @@ public:
     void button_down(Gosu::Button btn) override
     {
         if (btn == Gosu::KB_TAB) {
-            // Tab key will not be 'eaten' by text fields; use for switching through
-            // text fields.
+            // Tab key will not be consumed by Gosu::TextInput.
+            // Move focus to next text field.
             int index = -1;
             for (int i = 0; i < lengthof(text_fields); ++i) {
                 if (input().text_input() == text_fields[i].get()) {
@@ -162,9 +156,10 @@ public:
             input().set_text_input(text_fields[(index + 1) % lengthof(text_fields)].get());
         }
         else if (btn == Gosu::KB_ESCAPE) {
-            // Escape key will not be 'eaten' by text fields; use for deselecting.
+            // Escape key will not be consumed by Gosu::TextInput.
+            // Deselect all text fields.
             if (input().text_input()) {
-                input().set_text_input(0);
+                input().set_text_input(nullptr);
             }
             else {
                 close();
@@ -172,7 +167,7 @@ public:
         }
         else if (btn == Gosu::MS_LEFT) {
             // Mouse click: Select text field based on mouse position.
-            input().set_text_input(0);
+            input().set_text_input(nullptr);
             for (int i = 0; i < lengthof(text_fields); ++i) {
                 if (text_fields[i]->is_under_point(input().mouse_x(), input().mouse_y())) {
                     input().set_text_input(text_fields[i].get());

--- a/examples/TextInput/TextInput.cpp
+++ b/examples/TextInput/TextInput.cpp
@@ -67,7 +67,7 @@ public:
         }
         
         Gosu::Graphics::draw_rect(x - PADDING, y - PADDING,
-                                  width() + 2 * PADDING, height + 2 * PADDING,
+                                  width() + 2 * PADDING, height() + 2 * PADDING,
                                   background_color, 0);
         
         // Calculate the position of the caret and the selection start.
@@ -76,7 +76,7 @@ public:
         
         // Draw the selection background, if any; if not, sel_x and pos_x will be
         // the same value, making this rect empty and invisible.
-        Gosu::Graphics::draw_rect(sel_x, y, pos_x - sel_y, height(), SELECTION_COLOR, 0);
+        Gosu::Graphics::draw_rect(sel_x, y, pos_x - sel_x, height(), SELECTION_COLOR, 0);
 
         // Draw the caret if this is the currently selected field.
         if (window.input().text_input() == this) {

--- a/src/GosuAppDelegate.mm
+++ b/src/GosuAppDelegate.mm
@@ -17,7 +17,7 @@ Gosu::Window& window_instance();
 
 - (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions
 {
-    self.window = (__bridge UIWindow*) window_instance().UIWindow();
+    self.window = (__bridge UIWindow*)window_instance().uikit_window();
     [self.window makeKeyAndVisible];
     
     return YES;

--- a/src/GosuGLView.cpp
+++ b/src/GosuGLView.cpp
@@ -43,7 +43,7 @@ namespace Gosu
 
 - (id)initWithFrame:(CGRect)frame
 {
-    if ((self = [super initWithFrame:frame])) {
+    if (self = [super initWithFrame:frame]) {
         [self initializeGosuGLView];
     }
     
@@ -52,7 +52,7 @@ namespace Gosu
 
 - (id)initWithCoder:(NSCoder*)aDecoder
 {
-    if ((self = [super initWithCoder:aDecoder])) {
+    if (self = [super initWithCoder:aDecoder]) {
         [self initializeGosuGLView];
     }
     

--- a/src/GosuGLView.cpp
+++ b/src/GosuGLView.cpp
@@ -11,10 +11,6 @@
 #import <OpenGLES/ES1/glext.h>
 #import <QuartzCore/QuartzCore.h>
 
-#import <algorithm>
-
-using namespace std;
-
 
 static EAGLContext __weak* globalContext;
 
@@ -32,60 +28,8 @@ namespace Gosu
     }
 }
 
-#pragma mark - GosuTextPosition
-
-@interface GosuTextPosition : UITextPosition
-
-@property (nonatomic) NSInteger position;
-
-@end
-
-@implementation GosuTextPosition
-
-- (instancetype)initWithPosition:(NSInteger)position
-{
-    if (self = [super init]) {
-        _position = position;
-    }
-    return self;
-}
-
-@end
-
-#pragma mark - GosuTextRange
-
-@interface GosuTextRange : UITextRange
-
-@property (nonatomic, readonly) GosuTextPosition* start;
-@property (nonatomic, readonly) GosuTextPosition* end;
-
-@end
-
-@implementation GosuTextRange
-
-@synthesize start = _start;
-@synthesize end   = _end;
-
-- (instancetype)initWithStart:(NSInteger)start end:(NSInteger)end
-{
-    if (self = [super init]) {
-        _start = [[GosuTextPosition alloc] initWithPosition:start];
-        _end   = [[GosuTextPosition alloc] initWithPosition:end];
-    }
-    return self;
-}
-
-- (BOOL)isEmpty
-{
-    return _start.position == _end.position;
-}
-
-@end
-
-
 @implementation GosuGLView
 {
-    Gosu::Input* _input;
     EAGLContext* _context;
 
     GLint _backingWidth;
@@ -95,13 +39,11 @@ namespace Gosu
     GLuint _viewFramebuffer;
 }
 
-- (instancetype)initWithFrame:(CGRect)frame input:(Gosu::Input&)input
+- (instancetype)initWithFrame:(CGRect)frame
 {
     if (self = [super initWithFrame:frame]) {
         CAEAGLLayer* layer = (CAEAGLLayer*)self.layer;
         layer.opaque = YES;
-        
-        _input = &input;
         
         globalContext = _context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES1];
         [EAGLContext setCurrentContext:_context];
@@ -177,53 +119,31 @@ namespace Gosu
     _viewRenderbuffer = 0;
 }
 
-#pragma mark - NSResponder / UITextInput
+#pragma mark - NSResponder / UIKeyInput
 
 - (BOOL)canBecomeFirstResponder
 {
-    return _input->text_input() != nullptr;
+    return _input && _input->text_input();
 }
 
-- (NSString*)textInRange:(UITextRange*)range
+- (BOOL)hasText
 {
-    if (_input->text_input() == nullptr) return nil;
-    
-    NSString* string = @(_input->text_input()->text().c_str());
-    auto start = ((GosuTextPosition*)range.start).position;
-    auto length = ((GosuTextPosition*)range.end).position - start;
-    return [string substringWithRange:NSMakeRange(start, length)];
+    return _input && _input->text_input() && !_input->text_input()->text().empty();
 }
 
-- (void)replaceRange:(UITextRange*)range withText:(NSString*)text
+- (void)insertText:(NSString*)text
 {
-    NSString* string = @(_input->text_input()->text().c_str());
-    auto start = ((GosuTextPosition*)range.start).position;
-    auto length = ((GosuTextPosition*)range.end).position - start;
-    string = [string stringByReplacingCharactersInRange:NSMakeRange(start, length) withString:text];
-    _input->text_input()->set_text(string.UTF8String ?: "");
-    _input->text_input()->set_selection_start(static_cast<unsigned>(start + length));
+    if (_input && _input->text_input()) {
+        _input->text_input()->insert_text(text.UTF8String ?: "");
+    }
 }
 
-- (UITextRange*)selectedTextRange
+- (void)deleteBackward
 {
-    if (_input->text_input() == nullptr) return nil;
-    
-    auto& text_input = *_input->text_input();
-    auto start = min(text_input.selection_start(), text_input.caret_pos());
-    auto end   = max(text_input.selection_start(), text_input.caret_pos());
-    return [[GosuTextRange alloc] initWithStart:start end:end];
+    if (_input && _input->text_input()) {
+        _input->text_input()->delete_backward();
+    }
 }
-
-- (void)setSelectedTextRange:(UITextRange*)selectedTextRange
-{
-    if (_input->text_input() == nullptr) return;
-
-    GosuTextRange* range = (GosuTextRange*)selectedTextRange;
-    _input->text_input()->set_selection_start(static_cast<unsigned>(range.start.position));
-    _input->text_input()->set_caret_pos(static_cast<unsigned>(range.end.position));
-}
-
-
 
 @end
 

--- a/src/GosuGLView.cpp
+++ b/src/GosuGLView.cpp
@@ -2,12 +2,19 @@
 #if defined(GOSU_IS_IPHONE)
 
 #import "GosuGLView.hpp"
+#import <Gosu/Input.hpp>
+#import <Gosu/TextInput.hpp>
 
 #import <OpenGLES/EAGL.h>
 #import <OpenGLES/EAGLDrawable.h>
 #import <OpenGLES/ES1/gl.h>
 #import <OpenGLES/ES1/glext.h>
 #import <QuartzCore/QuartzCore.h>
+
+#import <algorithm>
+
+using namespace std;
+
 
 static EAGLContext __weak* globalContext;
 
@@ -25,10 +32,62 @@ namespace Gosu
     }
 }
 
+#pragma mark - GosuTextPosition
+
+@interface GosuTextPosition : UITextPosition
+
+@property (nonatomic) NSInteger position;
+
+@end
+
+@implementation GosuTextPosition
+
+- (instancetype)initWithPosition:(NSInteger)position
+{
+    if (self = [super init]) {
+        _position = position;
+    }
+    return self;
+}
+
+@end
+
+#pragma mark - GosuTextRange
+
+@interface GosuTextRange : UITextRange
+
+@property (nonatomic, readonly) GosuTextPosition* start;
+@property (nonatomic, readonly) GosuTextPosition* end;
+
+@end
+
+@implementation GosuTextRange
+
+@synthesize start = _start;
+@synthesize end   = _end;
+
+- (instancetype)initWithStart:(NSInteger)start end:(NSInteger)end
+{
+    if (self = [super init]) {
+        _start = [[GosuTextPosition alloc] initWithPosition:start];
+        _end   = [[GosuTextPosition alloc] initWithPosition:end];
+    }
+    return self;
+}
+
+- (BOOL)isEmpty
+{
+    return _start.position == _end.position;
+}
+
+@end
+
+
 @implementation GosuGLView
 {
+    Gosu::Input* _input;
     EAGLContext* _context;
-    
+
     GLint _backingWidth;
     GLint _backingHeight;
 
@@ -36,39 +95,22 @@ namespace Gosu
     GLuint _viewFramebuffer;
 }
 
-+ (Class)layerClass
-{
-    return [CAEAGLLayer class];
-}
-
-- (id)initWithFrame:(CGRect)frame
+- (instancetype)initWithFrame:(CGRect)frame input:(Gosu::Input&)input
 {
     if (self = [super initWithFrame:frame]) {
-        [self initializeGosuGLView];
+        CAEAGLLayer* layer = (CAEAGLLayer*)self.layer;
+        layer.opaque = YES;
+        
+        _input = &input;
+        
+        globalContext = _context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES1];
+        [EAGLContext setCurrentContext:_context];
+        
+        self.exclusiveTouch = YES;
+        self.multipleTouchEnabled = YES;
     }
     
     return self;
-}
-
-- (id)initWithCoder:(NSCoder*)aDecoder
-{
-    if (self = [super initWithCoder:aDecoder]) {
-        [self initializeGosuGLView];
-    }
-    
-    return self;
-}
-
-- (void)initializeGosuGLView
-{
-    CAEAGLLayer* layer = (CAEAGLLayer*)self.layer;
-    layer.opaque = YES;
-    
-    globalContext = _context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES1];
-    [EAGLContext setCurrentContext:_context];
-    
-    self.exclusiveTouch = YES;
-    self.multipleTouchEnabled = YES;
 }
 
 - (void)dealloc
@@ -91,6 +133,13 @@ namespace Gosu
     glBindRenderbufferOES(GL_RENDERBUFFER_OES, _viewRenderbuffer);
     
     [_context presentRenderbuffer:GL_RENDERBUFFER_OES];
+}
+
+#pragma mark - UIView
+
++ (Class)layerClass
+{
+    return [CAEAGLLayer class];
 }
 
 - (void)layoutSubviews
@@ -127,6 +176,54 @@ namespace Gosu
     glDeleteRenderbuffersOES(1, &_viewRenderbuffer);
     _viewRenderbuffer = 0;
 }
+
+#pragma mark - NSResponder / UITextInput
+
+- (BOOL)canBecomeFirstResponder
+{
+    return _input->text_input() != nullptr;
+}
+
+- (NSString*)textInRange:(UITextRange*)range
+{
+    if (_input->text_input() == nullptr) return nil;
+    
+    NSString* string = @(_input->text_input()->text().c_str());
+    auto start = ((GosuTextPosition*)range.start).position;
+    auto length = ((GosuTextPosition*)range.end).position - start;
+    return [string substringWithRange:NSMakeRange(start, length)];
+}
+
+- (void)replaceRange:(UITextRange*)range withText:(NSString*)text
+{
+    NSString* string = @(_input->text_input()->text().c_str());
+    auto start = ((GosuTextPosition*)range.start).position;
+    auto length = ((GosuTextPosition*)range.end).position - start;
+    string = [string stringByReplacingCharactersInRange:NSMakeRange(start, length) withString:text];
+    _input->text_input()->set_text(string.UTF8String ?: "");
+    _input->text_input()->set_selection_start(static_cast<unsigned>(start + length));
+}
+
+- (UITextRange*)selectedTextRange
+{
+    if (_input->text_input() == nullptr) return nil;
+    
+    auto& text_input = *_input->text_input();
+    auto start = min(text_input.selection_start(), text_input.caret_pos());
+    auto end   = max(text_input.selection_start(), text_input.caret_pos());
+    return [[GosuTextRange alloc] initWithStart:start end:end];
+}
+
+- (void)setSelectedTextRange:(UITextRange*)selectedTextRange
+{
+    if (_input->text_input() == nullptr) return;
+
+    GosuTextRange* range = (GosuTextRange*)selectedTextRange;
+    _input->text_input()->set_selection_start(static_cast<unsigned>(range.start.position));
+    _input->text_input()->set_caret_pos(static_cast<unsigned>(range.end.position));
+}
+
+
 
 @end
 

--- a/src/GosuGLView.hpp
+++ b/src/GosuGLView.hpp
@@ -1,7 +1,11 @@
 #import <UIKit/UIKit.h>
+#import <Gosu/Fwd.hpp>
 
+@interface GosuGLView : UIView <UITextInput>
 
-@interface GosuGLView : UIView
+- (instancetype)initWithFrame:(CGRect)frame input:(Gosu::Input&)input;
+- (instancetype)initWithFrame:(CGRect)frame NS_UNAVAILABLE;
+- (instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
 
 - (void)redrawGL:(void (^)())code;
 

--- a/src/GosuGLView.hpp
+++ b/src/GosuGLView.hpp
@@ -1,12 +1,14 @@
 #import <UIKit/UIKit.h>
 #import <Gosu/Fwd.hpp>
 
-@interface GosuGLView : UIView <UITextInput>
+@interface GosuGLView : UIView <UIKeyInput>
 
-- (instancetype)initWithFrame:(CGRect)frame input:(Gosu::Input&)input;
-- (instancetype)initWithFrame:(CGRect)frame NS_UNAVAILABLE;
-- (instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
+- (instancetype)initWithFrame:(CGRect)frame NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithCoder:(NSCoder*)aDecoder NS_UNAVAILABLE;
 
 - (void)redrawGL:(void (^)())code;
+
+// This property must be set in order for TextInput handling to work.
+@property (nonatomic, assign) Gosu::Input* input;
 
 @end

--- a/src/GosuViewController.cpp
+++ b/src/GosuViewController.cpp
@@ -39,7 +39,8 @@ static void handle_audio_interruption(void* unused, UInt32 inInterruptionState)
 
 - (void)loadView
 {
-    self.view = [[GosuGLView alloc] initWithFrame:[UIScreen mainScreen].bounds];
+    self.view = [[GosuGLView alloc] initWithFrame:[UIScreen mainScreen].bounds
+                                            input:self.gosuWindowReference.input()];
 }
 
 - (BOOL)prefersStatusBarHidden
@@ -198,25 +199,25 @@ static void handle_audio_interruption(void* unused, UInt32 inInterruptionState)
 - (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event
 {
     auto& input = self.gosuWindowReference.input();
-    input.feed_touch_event(input.on_touch_began, (__bridge void*) touches);
+    input.feed_touch_event(input.on_touch_began, (__bridge void*)touches);
 }
 
 - (void)touchesMoved:(NSSet*)touches withEvent:(UIEvent*)event
 {
     auto& input = self.gosuWindowReference.input();
-    input.feed_touch_event(input.on_touch_moved, (__bridge void*) touches);
+    input.feed_touch_event(input.on_touch_moved, (__bridge void*)touches);
 }
 
 - (void)touchesEnded:(NSSet*)touches withEvent:(UIEvent*)event
 {
     auto& input = self.gosuWindowReference.input();
-    input.feed_touch_event(input.on_touch_ended, (__bridge void*) touches);
+    input.feed_touch_event(input.on_touch_ended, (__bridge void*)touches);
 }
 
 - (void)touchesCancelled:(NSSet*)touches withEvent:(UIEvent*)event
 {
     auto& input = self.gosuWindowReference.input();
-    input.feed_touch_event(input.on_touch_cancelled, (__bridge void*) touches);
+    input.feed_touch_event(input.on_touch_cancelled, (__bridge void*)touches);
 }
 
 @end

--- a/src/GosuViewController.cpp
+++ b/src/GosuViewController.cpp
@@ -39,8 +39,7 @@ static void handle_audio_interruption(void* unused, UInt32 inInterruptionState)
 
 - (void)loadView
 {
-    self.view = [[GosuGLView alloc] initWithFrame:[UIScreen mainScreen].bounds
-                                            input:self.gosuWindowReference.input()];
+    self.view = [[GosuGLView alloc] initWithFrame:[UIScreen mainScreen].bounds];
 }
 
 - (BOOL)prefersStatusBarHidden
@@ -56,11 +55,6 @@ static void handle_audio_interruption(void* unused, UInt32 inInterruptionState)
 - (NSUInteger)supportedInterfaceOrientations
 {
     return UIInterfaceOrientationMaskLandscape;
-}
-
-- (GosuGLView*)GLView
-{
-    return (GosuGLView*)self.view;
 }
 
 - (Gosu::Window&)gosuWindowReference
@@ -183,7 +177,7 @@ static void handle_audio_interruption(void* unused, UInt32 inInterruptionState)
     }
     
     if (window.needs_redraw()) {
-        [self.GLView redrawGL:^{
+        [(GosuGLView*)self.view redrawGL:^{
             window.graphics().frame([&window] {
                 window.draw();
                 Gosu::FPS::register_frame();
@@ -192,6 +186,13 @@ static void handle_audio_interruption(void* unused, UInt32 inInterruptionState)
     }
     
     Gosu::Song::update();
+}
+
+#pragma mark - Input setup
+
+- (void)trackTextInput:(Gosu::Input&)input
+{
+    ((GosuGLView*)self.view).input = &input;
 }
 
 #pragma mark - Touch forwarding

--- a/src/GosuViewController.cpp
+++ b/src/GosuViewController.cpp
@@ -159,7 +159,7 @@ static void handle_audio_interruption(void* unused, UInt32 inInterruptionState)
     
     if (60 % targetFPS != 0) {
         NSTimeInterval interval = self.gosuWindowReference.update_interval() / 1000.0;
-        NSTimer* timer          = [NSTimer scheduledTimerWithTimeInterval:interval
+        NSTimer* timer = [NSTimer scheduledTimerWithTimeInterval:interval
                                                           target:self
                                                         selector:@selector(updateAndDraw:)
                                                         userInfo:nil
@@ -203,22 +203,26 @@ static void handle_audio_interruption(void* unused, UInt32 inInterruptionState)
 
 - (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event
 {
-    self.gosuWindowReference.input().feed_touch_event(0, (__bridge void*) touches);
+    auto& input = self.gosuWindowReference.input();
+    input.feed_touch_event(input.on_touch_began, (__bridge void*) touches);
 }
 
 - (void)touchesMoved:(NSSet*)touches withEvent:(UIEvent*)event
 {
-    self.gosuWindowReference.input().feed_touch_event(1, (__bridge void*) touches);
+    auto& input = self.gosuWindowReference.input();
+    input.feed_touch_event(input.on_touch_moved, (__bridge void*) touches);
 }
 
 - (void)touchesEnded:(NSSet*)touches withEvent:(UIEvent*)event
 {
-    self.gosuWindowReference.input().feed_touch_event(2, (__bridge void*) touches);
+    auto& input = self.gosuWindowReference.input();
+    input.feed_touch_event(input.on_touch_ended, (__bridge void*) touches);
 }
 
 - (void)touchesCancelled:(NSSet*)touches withEvent:(UIEvent*)event
 {
-    self.gosuWindowReference.input().feed_touch_event(3, (__bridge void*) touches);
+    auto& input = self.gosuWindowReference.input();
+    input.feed_touch_event(input.on_touch_cancelled, (__bridge void*) touches);
 }
 
 @end

--- a/src/GosuViewController.cpp
+++ b/src/GosuViewController.cpp
@@ -52,11 +52,6 @@ static void handle_audio_interruption(void* unused, UInt32 inInterruptionState)
     return YES;
 }
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
-{
-    return UIInterfaceOrientationIsLandscape(interfaceOrientation);
-}
-
 - (NSUInteger)supportedInterfaceOrientations
 {
     return UIInterfaceOrientationMaskLandscape;
@@ -80,6 +75,7 @@ static void handle_audio_interruption(void* unused, UInt32 inInterruptionState)
 {
     [super viewDidLoad];
     
+    // TODO - replace with AVAudioSession https://stackoverflow.com/q/19710046
     AudioSessionInitialize(nullptr, nullptr, handle_audio_interruption, nullptr);
     
     [[NSNotificationCenter defaultCenter] addObserver:self
@@ -151,9 +147,7 @@ static void handle_audio_interruption(void* unused, UInt32 inInterruptionState)
 
 - (void)setupTimerOrDisplayLink
 {
-    if (_timerOrDisplayLink) {
-        return;
-    }
+    if (_timerOrDisplayLink) return;
     
     NSInteger targetFPS = round(1000.0 / self.gosuWindowReference.update_interval());
     

--- a/src/GosuViewController.hpp
+++ b/src/GosuViewController.hpp
@@ -1,12 +1,10 @@
 #import <UIKit/UIKit.h>
-
-
-@class GosuGLView;
+#import <Gosu/Fwd.hpp>
 
 
 @interface GosuViewController : UIViewController
 
-- (GosuGLView *)GLView;
+- (void)trackTextInput:(Gosu::Input&)input;
 
 @property (nonatomic, assign) void *gosuWindow;
 

--- a/src/InputUIKit.cpp
+++ b/src/InputUIKit.cpp
@@ -169,12 +169,12 @@ Gosu::TextInput* Gosu::Input::text_input() const
 void Gosu::Input::set_text_input(TextInput* text_input)
 {
     if (text_input) {
+        pimpl->text_input = text_input;
         [pimpl->view becomeFirstResponder];
     } else {
         [pimpl->view resignFirstResponder];
+        pimpl->text_input = nullptr;
     }
-
-    pimpl->text_input = text_input;
 }
 
 #endif

--- a/src/InputUIKit.cpp
+++ b/src/InputUIKit.cpp
@@ -9,7 +9,8 @@ using namespace std;
 
 struct Gosu::Input::Impl
 {
-    UIView* view;
+    UIView* view = nil;
+    TextInput* text_input = nullptr;
     float mouse_x, mouse_y;
     float scale_x, scale_y;
     float update_interval;
@@ -22,7 +23,7 @@ struct Gosu::Input::Impl
         CGPoint point = [ui_touch locationInView:view];
         
         return (Touch) {
-            .id = (__bridge void*) ui_touch,
+            .id = (__bridge void*)ui_touch,
             .x  = (float)point.x * scale_x,
             .y  = (float)point.y * scale_y,
         };
@@ -131,9 +132,7 @@ double Gosu::Input::accelerometer_z() const
 
 void Gosu::Input::update()
 {
-    // Check for dead touches and remove from vector if
-    // necessary
-
+    // Check for dead touches and remove from vector if necessary.
     NSMutableSet* dead_touches = nil;
 
     for (UITouch* touch in pimpl->current_touches_set) {
@@ -145,9 +144,7 @@ void Gosu::Input::update()
         }
         
         // Something was deleted, we will need the set.
-        if (!dead_touches) {
-            dead_touches = [NSMutableSet new];
-        }
+        if (!dead_touches) dead_touches = [NSMutableSet new];
         [dead_touches addObject:touch];
     }
     
@@ -166,12 +163,18 @@ void Gosu::Input::update()
 
 Gosu::TextInput* Gosu::Input::text_input() const
 {
-    return nullptr;
+    return pimpl->text_input;
 }
 
-void Gosu::Input::set_text_input(TextInput* input)
+void Gosu::Input::set_text_input(TextInput* text_input)
 {
-    throw "NYI";
+    if (text_input) {
+        [pimpl->view becomeFirstResponder];
+    } else {
+        [pimpl->view resignFirstResponder];
+    }
+
+    pimpl->text_input = text_input;
 }
 
 #endif

--- a/src/TextInput.cpp
+++ b/src/TextInput.cpp
@@ -1,24 +1,26 @@
-#include <Gosu/Platform.hpp>
-#if !defined(GOSU_IS_IPHONE)
-
 #include <Gosu/TextInput.hpp>
 #include <Gosu/Input.hpp>
 #include <Gosu/Platform.hpp>
+
+#ifndef GOSU_IS_IPHONE
 #include <SDL.h>
 #include <cctype>
+#endif
+
 using namespace std;
 
 struct Gosu::TextInput::Impl
 {
     string text;
     
-    // This is the current IME composition.
+    // This is the current IME composition (not used on iOS).
     // http://wiki.libsdl.org/Tutorials/TextInput#CandidateList
     string composition;
     
     // Indices into the UTF-8 encoded text.
     unsigned caret_pos = 0, selection_start = 0;
     
+#ifndef GOSU_IS_IPHONE
     // Skip continuation characters, see: https://en.wikipedia.org/wiki/UTF-8#Description
     // (0xc0 = 11'000000, 0x80 = 10'000000)
     bool should_skip(char ch)
@@ -143,6 +145,7 @@ struct Gosu::TextInput::Impl
             caret_pos = selection_start;
         }
     }
+#endif
 };
 
 Gosu::TextInput::TextInput()
@@ -152,6 +155,7 @@ Gosu::TextInput::TextInput()
 
 Gosu::TextInput::~TextInput()
 {
+    // TODO: Unset text_input to avoid stale pointers?
 }
 
 string Gosu::TextInput::text() const
@@ -172,12 +176,12 @@ void Gosu::TextInput::set_text(const string& text)
 
 unsigned Gosu::TextInput::caret_pos() const
 {
-    return static_cast<unsigned>(pimpl->caret_pos);
+    return pimpl->caret_pos;
 }
 
-void Gosu::TextInput::set_caret_pos(unsigned pos)
+void Gosu::TextInput::set_caret_pos(unsigned caret_pos)
 {
-    pimpl->caret_pos = pos;
+    pimpl->caret_pos = caret_pos;
 }
 
 unsigned Gosu::TextInput::selection_start() const
@@ -185,11 +189,12 @@ unsigned Gosu::TextInput::selection_start() const
     return pimpl->selection_start;
 }
 
-void Gosu::TextInput::set_selection_start(unsigned pos)
+void Gosu::TextInput::set_selection_start(unsigned selection_start)
 {
-    pimpl->selection_start = pos;
+    pimpl->selection_start = selection_start;
 }
 
+#ifndef GOSU_IS_IPHONE
 bool Gosu::TextInput::feed_sdl_event(void* event)
 {
     const SDL_Event* e = static_cast<SDL_Event*>(event);
@@ -275,5 +280,4 @@ bool Gosu::TextInput::feed_sdl_event(void* event)
     
     return false;
 }
-
 #endif

--- a/src/TextInput.cpp
+++ b/src/TextInput.cpp
@@ -20,7 +20,6 @@ struct Gosu::TextInput::Impl
     // Indices into the UTF-8 encoded text.
     unsigned caret_pos = 0, selection_start = 0;
     
-#ifndef GOSU_IS_IPHONE
     // Skip continuation characters, see: https://en.wikipedia.org/wiki/UTF-8#Description
     // (0xc0 = 11'000000, 0x80 = 10'000000)
     bool should_skip(char ch)
@@ -145,7 +144,6 @@ struct Gosu::TextInput::Impl
             caret_pos = selection_start;
         }
     }
-#endif
 };
 
 Gosu::TextInput::TextInput()
@@ -155,7 +153,7 @@ Gosu::TextInput::TextInput()
 
 Gosu::TextInput::~TextInput()
 {
-    // TODO: Unset text_input to avoid stale pointers?
+    // TODO: Unset Input::text_input to avoid stale pointers?
 }
 
 string Gosu::TextInput::text() const
@@ -281,3 +279,18 @@ bool Gosu::TextInput::feed_sdl_event(void* event)
     return false;
 }
 #endif
+
+void Gosu::TextInput::insert_text(string text)
+{
+    pimpl->insert_text(text);
+}
+
+void Gosu::TextInput::delete_forward()
+{
+    pimpl->delete_forward();
+}
+
+void Gosu::TextInput::delete_backward()
+{
+    pimpl->delete_backward();
+}

--- a/src/WindowUIKit.cpp
+++ b/src/WindowUIKit.cpp
@@ -3,7 +3,9 @@
 
 #include "GosuViewController.hpp"
 #include <Gosu/Gosu.hpp>
+
 using namespace std;
+
 
 namespace Gosu
 {
@@ -65,6 +67,9 @@ Gosu::Window::Window(unsigned width, unsigned height, bool fullscreen, double up
     pimpl->input->on_touch_moved = [this](Gosu::Touch touch) { touch_moved(touch); };
     pimpl->input->on_touch_ended = [this](Gosu::Touch touch) { touch_ended(touch); };
     pimpl->input->on_touch_cancelled = [this](Gosu::Touch touch) { touch_cancelled(touch); };
+    
+    // Now let the controller know about our Input instance.
+    [pimpl->controller trackTextInput:*pimpl->input];
     
     pimpl->fullscreen = fullscreen;
     pimpl->update_interval = update_interval;

--- a/src/WindowUIKit.cpp
+++ b/src/WindowUIKit.cpp
@@ -34,7 +34,7 @@ namespace Gosu
 
 struct Gosu::Window::Impl
 {
-    ::UIWindow* window;
+    UIWindow* window;
     GosuViewController* controller;
     unique_ptr<Graphics> graphics;
     unique_ptr<Input> input;
@@ -47,7 +47,7 @@ struct Gosu::Window::Impl
 Gosu::Window::Window(unsigned width, unsigned height, bool fullscreen, double update_interval)
 : pimpl(new Impl)
 {
-    pimpl->window = [[::UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+    pimpl->window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
     pimpl->controller = [GosuViewController new];
     pimpl->controller.gosuWindow = this;
     pimpl->window.rootViewController = pimpl->controller;
@@ -152,7 +152,7 @@ void Gosu::Window::button_down(Button button)
 {
 }
 
-void* Gosu::Window::UIWindow() const
+void* Gosu::Window::uikit_window() const
 {
     return (__bridge void*) pimpl->window;
 }


### PR DESCRIPTION
Implements UIKit support for TextInput (which must then be wrapped in motion-gosu for https://github.com/gosu/motion-gosu/issues/6).

- [x] Make TextInput.cpp compile on iOS too (instead of dumb stubs in Input.cpp)
- [x] Implement ~~UITextInput~~ UIKeyInput protocol in GosuGLView (deferring to current TextInput instance)
- [ ] ~~Make TextInput available in motion-gosu (macOS)~~ -> happens after this PR
- [ ] ~~Make TextInput available in motion-gosu (iOS if extra work is needed?)~~ -> happens after this PR