### PR TITLE
Add `void Window::set_window_icon(const Bitmap&)`

### DIFF
--- a/Gosu/Window.hpp
+++ b/Gosu/Window.hpp
@@ -49,6 +49,8 @@ namespace Gosu
         std::string caption() const;
         void set_caption(const std::string& caption);
 
+        void set_window_icon(const Bitmap& icon);
+
         //! Enters a modal loop where the Window is visible on screen and
         //! receives calls to draw, update etc.
         virtual void show();

--- a/examples/Tutorial/Tutorial.cpp
+++ b/examples/Tutorial/Tutorial.cpp
@@ -147,11 +147,9 @@ public:
     {
         set_caption("Gosu Tutorial Game");
 
-        {
-            Gosu::Bitmap icon;
-            Gosu::load_image_file(icon, Gosu::resource_prefix() + "media/Starfighter.bmp");
-            set_window_icon(icon);
-        }
+        Gosu::Bitmap icon;
+        Gosu::load_image_file(icon, Gosu::resource_prefix() + "media/Starfighter.bmp");
+        set_window_icon(icon);
 
         std::string filename = Gosu::resource_prefix() + "media/Space.png";
         background_image = Gosu::Image(filename, Gosu::IF_TILEABLE);

--- a/examples/Tutorial/Tutorial.cpp
+++ b/examples/Tutorial/Tutorial.cpp
@@ -147,6 +147,12 @@ public:
     {
         set_caption("Gosu Tutorial Game");
 
+        {
+            Gosu::Bitmap icon;
+            Gosu::load_image_file(icon, Gosu::resource_prefix() + "media/Starfighter.bmp");
+            set_window_icon(icon);
+        }
+
         std::string filename = Gosu::resource_prefix() + "media/Space.png";
         background_image = Gosu::Image(filename, Gosu::IF_TILEABLE);
 

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -247,6 +247,38 @@ void Gosu::Window::set_caption(const string& caption)
     SDL_SetWindowTitle(shared_window(), caption.c_str());
 }
 
+void Gosu::Window::set_window_icon(const Bitmap& icon)
+{
+    #ifdef GOSU_IS_LITTLE_ENDIAN
+    enum { RED_OFFSET = 0, GREEN_OFFSET = 8, BLUE_OFFSET = 16, ALPHA_OFFSET = 24 };
+    #else
+    enum { RED_OFFSET = 24, GREEN_OFFSET = 16, BLUE_OFFSET = 8, ALPHA_OFFSET = 0 };
+    #endif
+
+    void* pixels = const_cast<Color*>(icon.data());
+    int width = icon.width();
+    int height = icon.height();
+    int depth = 8 * sizeof(Color); // Number of bits.
+    int pitch = width * sizeof(Color); // Number of bytes.
+    Uint32 red_mask = 0xff << RED_OFFSET;
+    Uint32 green_mask = 0xff << GREEN_OFFSET;
+    Uint32 blue_mask = 0xff << BLUE_OFFSET;
+    Uint32 alpha_mask = 0xff << ALPHA_OFFSET;
+
+    SDL_Surface* surface = SDL_CreateRGBSurfaceFrom(pixels, width, height, depth, pitch,
+        red_mask, green_mask, blue_mask, alpha_mask);
+    if (surface == nullptr) {
+        throw_sdl_error("Could not create icon");
+    }
+
+    // Surface's pixels are copied.
+    SDL_SetWindowIcon(shared_window(), surface);
+
+    // Bitmap's pixels are not freed because the Surface was created with
+    // SDL_CreateRGBSurfaceFrom().
+    SDL_FreeSurface(surface);
+}
+
 void Gosu::Window::show()
 {
     unsigned long time_before_tick = milliseconds();

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -258,8 +258,8 @@ void Gosu::Window::set_window_icon(const Bitmap& icon)
     void* pixels = const_cast<Color*>(icon.data());
     int width = icon.width();
     int height = icon.height();
-    int depth = 8 * sizeof(Color); // Number of bits.
-    int pitch = width * sizeof(Color); // Number of bytes.
+    int depth = 8 * sizeof(Color); // Number of bits per pixel.
+    int pitch = width * sizeof(Color); // Number of bytes per row of pixels.
     Uint32 red_mask = 0xff << RED_OFFSET;
     Uint32 green_mask = 0xff << GREEN_OFFSET;
     Uint32 blue_mask = 0xff << BLUE_OFFSET;


### PR DESCRIPTION
Here's a simple implementation for #506. This PR also sets the icon for TutorialExample to Starfighter.bmp.

I've tested it on macOS. I'm not sure what would happen on other platforms, but we should be able to look at SDL_SetWindowIcon() to see what would happen.

Looks like it supports the alpha channel. Yay! :)

Here's a screenshot of TutorialExample. You can see the icon in the dock.

![Window icon in TutorialExample on macOS](https://user-images.githubusercontent.com/107998/64741238-ab01dc00-d4ac-11e9-9e4f-e40a8dfde7f1.png)
