### PR TITLE
Use Xcode 8.3 and Xcode 11.0 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ matrix:
       dist: xenial
       sudo: required
       compiler: gcc
-    # macOS 10.11 El Capitan
+    # macOS 10.12 Sierra with last Xcode 8 release
     - os: osx
-      osx_image: xcode7.3
+      osx_image: xcode8.3
       compiler: clang
-    # Xcode 8 beta
+    # macOS 10.14 Mojave with first Xcode 11 release
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode11
       compiler: clang
 
 # Linux dependencies
@@ -39,9 +39,6 @@ services:
   - xvfb
 
 before_install:
-  # Cause multi-line snippets to fail on first error.
-  - set -ev
-
   # Print the Ruby configuration to see what's defined in CXXFLAGS etc.
   - ruby -rrbconfig -e 'RbConfig::CONFIG.each { |k, v| puts [k, v].join("=") }'
 
@@ -128,6 +125,3 @@ script:
     cd examples/build &&
     cmake .. &&
     make
-
-  # Reset the 'e' option to avoid a shell_session_update error from Travis.
-  - set +ev


### PR DESCRIPTION
Now that Homebrew has updated to SDL2 2.0.10, SDL2 fails to build on Xcode 7.x and Xcode 8.0 with the error "use of undeclared identifier 'NSEventSubtypeMouseEvent'", which is a symbol that was introduced in macOS Sierra. Building with Xcode 8.3, which has the Sierra SDK, fixes the issue. This is a regression introduced in SDL2 2.0.10 that will be fixed in SDL2 2.0.11. But until that is released and added to Homebrew, Travis just going to build every build.

- Update "old Mac" Travis build to use macOS Sierra with Xcode 8.3.3.
- Update "new Mac" Travis build to use the latest Travis image, which is macOS Mojave with Xcode 11.0.
- Don't `set -ev` in Travis as this fails the build on these new images.

See: https://travis-ci.org/gosu/gosu/jobs/583899519
See: https://travis-ci.org/gosu/gosu/jobs/583899520
See: https://discourse.libsdl.org/t/sdl-2-0-10-old-mac-os-el-capitan-10-11-and-xcode7-3/26554
See: https://hg.libsdl.org/SDL/rev/449d5819a84a
See: https://github.com/Homebrew/homebrew-core/pull/42619