### PR TITLE
Include <stdexcept> to fix compile errors on GCC 10.

### DIFF
--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -10,6 +10,7 @@
 #include <array>
 #include <cassert>
 #include <map>
+#include <stdexcept>
 using namespace std;
 
 static const int FONT_RENDER_SCALE = 2;

--- a/src/LargeImageData.cpp
+++ b/src/LargeImageData.cpp
@@ -3,6 +3,7 @@
 #include <Gosu/Graphics.hpp>
 #include <Gosu/Math.hpp>
 #include <cmath>
+#include <stdexcept>
 using namespace std;
 
 Gosu::LargeImageData::LargeImageData(const Bitmap& source, int tile_width, int tile_height,

--- a/src/Text.cpp
+++ b/src/Text.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <algorithm>
 #include <vector>
+#include <stdexcept>
 using namespace std;
 
 double Gosu::text_width(const u32string& text,

--- a/src/TrueTypeFont.cpp
+++ b/src/TrueTypeFont.cpp
@@ -1,6 +1,7 @@
 #include "TrueTypeFont.hpp"
 #include <Gosu/IO.hpp>
 #include <Gosu/Text.hpp>
+#include <stdexcept>
 
 // Disable comma warnings in stb headers.
 #ifdef __GNUC__


### PR DESCRIPTION
Gem fails to compile native extensions on GCC 10. This PR fixes that by including <stdexcept> in files that need it.
I tested this by successfully building the gem, installing it, and displaying a simple window on Fedora 32.
Fixes: https://github.com/gosu/gosu/issues/530