### PR TITLE
Possibly fix window scaling weirdness for resizable windows

### DIFF
--- a/ext/gosu/extconf.rb
+++ b/ext/gosu/extconf.rb
@@ -51,7 +51,7 @@ if windows
   else
     $LDFLAGS << "  -L../../dependencies/al_soft/x86 -L../../dependencies/SDL/lib/x86"
   end
-  $LDFLAGS << " -lgdi32 -lwinmm -lOpenGL32 -lOpenAL32 -lSDL2"
+  $LDFLAGS << " -lgdi32 -lwinmm -ldwmapi -lOpenGL32 -lOpenAL32 -lSDL2"
   # Link libstdc++ statically to avoid having another DLL dependency when using Ocra.
   $LDFLAGS << " -static-libstdc++"
 elsif macos

--- a/src/Resolution.cpp
+++ b/src/Resolution.cpp
@@ -28,6 +28,114 @@ int Gosu::screen_height(Window* window)
     return display_mode(window).h;
 }
 
+#ifdef GOSU_IS_MAC
+#import <AppKit/AppKit.h>
+
+static NSSize max_window_size(Gosu::Window* window)
+{
+    // The extra size that a window needs depends on its style.
+    // This logic must be kept in sync with SDL_cocoawindow.m to be 100% accurate.
+    NSUInteger style;
+    if (window && window->borderless()) {
+        style = NSWindowStyleMaskBorderless;
+    }
+    else {
+        style = (NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable);
+    }
+    if (window && window->resizable()) {
+        style |= NSWindowStyleMaskResizable;
+    }
+
+    auto index = window ? SDL_GetWindowDisplayIndex(Gosu::shared_window()) : 0;
+    auto screen_frame = NSScreen.screens[index].visibleFrame;
+    return[NSWindow contentRectForFrameRect : screen_frame styleMask : style].size;
+}
+
+int Gosu::available_width(Window* window)
+{
+    return max_window_size(window).width;
+}
+
+int Gosu::available_height(Window* window)
+{
+    return max_window_size(window).height;
+}
+#endif
+
+// TODO: Remove this implementation and remove ifdef for GOSU_IS_X once WIN_GetWindowBordersSize is patched
+#ifdef GOSU_IS_WIN
+#include <windows.h>
+#include <SDL_syswm.h>
+#include <dwmapi.h>
+#pragma comment (lib, "Dwmapi.lib")
+
+static SDL_Rect max_window_size(Gosu::Window* window)
+{
+    // Replicate SDL's WIN_GetWindowBordersSize implementation (https://github.com/SDL-mirror/SDL/blob/e8ad67a12fff46af9927660603fdfa4cb74130be/src/video/windows/SDL_windowswindow.c#L514-L554)
+    // until it's patched to ignore the window drop shadow (window border is 1px but with drop shadow it's reported as 8px)
+    // REF: https://bugzilla.libsdl.org/show_bug.cgi?id=5302
+
+    static struct VideoSubsystem {
+        VideoSubsystem() { SDL_InitSubSystem(SDL_INIT_VIDEO); };
+        ~VideoSubsystem() { SDL_QuitSubSystem(SDL_INIT_VIDEO); };
+    } subsystem;
+
+    SDL_SysWMinfo info;
+    RECT rcClient, rcWindow;
+    POINT ptDiff;
+    SDL_Rect rect;
+    int top, left, bottom, right;
+
+    SDL_VERSION(&info.version);
+    SDL_GetWindowWMInfo(Gosu::shared_window(), &info);
+
+    HWND hwnd = info.info.win.window;
+
+    /* rcClient stores the size of the inner window, while rcWindow stores the outer size relative to the top-left
+     * screen position; so the top/left values of rcClient are always {0,0} and bottom/right are {height,width} */
+    GetClientRect(hwnd, &rcClient);
+    DwmGetWindowAttribute(hwnd, DWMWA_EXTENDED_FRAME_BOUNDS, &rcWindow, sizeof(rcWindow));
+
+    /* convert the top/left values to make them relative to
+     * the window; they will end up being slightly negative */
+    ptDiff.y = rcWindow.top;
+    ptDiff.x = rcWindow.left;
+
+    ScreenToClient(hwnd, &ptDiff);
+
+    rcWindow.top = ptDiff.y;
+    rcWindow.left = ptDiff.x;
+
+    /* convert the bottom/right values to make them relative to the window,
+     * these will be slightly bigger than the inner width/height */
+    ptDiff.y = rcWindow.bottom;
+    ptDiff.x = rcWindow.right;
+
+    ScreenToClient(hwnd, &ptDiff);
+
+    rcWindow.bottom = ptDiff.y;
+    rcWindow.right = ptDiff.x;
+
+    /* Now that both the inner and outer rects use the same coordinate system we can substract them to get the border size.
+     * Keep in mind that the top/left coordinates of rcWindow are negative because the border lies slightly before {0,0},
+     * so switch them around because SDL2 wants them in positive. */
+    top = rcClient.top - rcWindow.top;
+    left = rcClient.left - rcWindow.left;
+    bottom = rcWindow.bottom - rcClient.bottom;
+    right = rcWindow.right - rcClient.right;
+
+    int index = window ? SDL_GetWindowDisplayIndex(Gosu::shared_window()) : 0;
+    SDL_GetDisplayUsableBounds(index, &rect);
+
+    rect.w -= left + right;
+    rect.h -= top + bottom;
+
+    // Return a rect to have one less Gosu::available_width/height implementation.
+    return rect;
+}
+#endif
+
+#ifdef GOSU_IS_X
 static SDL_Rect max_window_size(Gosu::Window* window)
 {
     static struct VideoSubsystem {
@@ -37,9 +145,17 @@ static SDL_Rect max_window_size(Gosu::Window* window)
 
     int index = window ? SDL_GetWindowDisplayIndex(Gosu::shared_window()) : 0;
     SDL_Rect rect;
+    int top, left, bottom, right;
     SDL_GetDisplayUsableBounds(index, &rect);
+    SDL_GetWindowBordersSize(Gosu::shared_window(), &top, &left, &bottom, &right);
+
+    rect.w -= left + right;
+    rect.h -= top + bottom;
+
     return rect;
 }
+#endif
+
 
 int Gosu::available_width(Window* window)
 {

--- a/src/Resolution.cpp
+++ b/src/Resolution.cpp
@@ -11,7 +11,7 @@ static SDL_DisplayMode display_mode(Gosu::Window* window)
         VideoSubsystem()  { SDL_InitSubSystem(SDL_INIT_VIDEO); };
         ~VideoSubsystem() { SDL_QuitSubSystem(SDL_INIT_VIDEO); };
     } subsystem;
-    
+
     int index = window ? SDL_GetWindowDisplayIndex(Gosu::shared_window()) : 0;
     SDL_DisplayMode result;
     SDL_GetDesktopDisplayMode(index, &result);
@@ -28,101 +28,26 @@ int Gosu::screen_height(Window* window)
     return display_mode(window).h;
 }
 
-#ifdef GOSU_IS_MAC
-#import <AppKit/AppKit.h>
-
-static NSSize max_window_size(Gosu::Window* window)
+static SDL_Rect max_window_size(Gosu::Window* window)
 {
-    // The extra size that a window needs depends on its style.
-    // This logic must be kept in sync with SDL_cocoawindow.m to be 100% accurate.
-    NSUInteger style;
-    if (window && window->borderless()) {
-        style = NSWindowStyleMaskBorderless;
-    }
-    else {
-        style = (NSWindowStyleMaskTitled|NSWindowStyleMaskClosable|NSWindowStyleMaskMiniaturizable);
-    }
-    if (window && window->resizable()) {
-        style |= NSWindowStyleMaskResizable;
-    }
+    static struct VideoSubsystem {
+        VideoSubsystem() { SDL_InitSubSystem(SDL_INIT_VIDEO); };
+        ~VideoSubsystem() { SDL_QuitSubSystem(SDL_INIT_VIDEO); };
+    } subsystem;
 
-    auto index = window ? SDL_GetWindowDisplayIndex(Gosu::shared_window()) : 0;
-    auto screen_frame = NSScreen.screens[index].visibleFrame;
-    return [NSWindow contentRectForFrameRect:screen_frame styleMask:style].size;
+    int index = window ? SDL_GetWindowDisplayIndex(Gosu::shared_window()) : 0;
+    SDL_Rect rect;
+    SDL_GetDisplayUsableBounds(index, &rect);
+    return rect;
 }
 
 int Gosu::available_width(Window* window)
 {
-    return max_window_size(window).width;
+    return max_window_size(window).w;
 }
 
 int Gosu::available_height(Window* window)
 {
-    return max_window_size(window).height;
+    return max_window_size(window).h;
 }
-#endif
-
-#ifdef GOSU_IS_WIN
-#include <windows.h>
-#include <SDL_syswm.h>
-
-static SIZE max_window_size(Gosu::Window* window)
-{
-    RECT work_area;
-    
-    if (window == nullptr) {
-        // Easy case: Return the work area of the primary monitor.
-        SystemParametersInfo(SPI_GETWORKAREA, 0, &work_area, 0);
-    }
-    else {
-        // Return the work area of the monitor the window is on.
-        SDL_SysWMinfo wm_info;
-        SDL_VERSION(&wm_info.version);
-        SDL_GetWindowWMInfo(Gosu::shared_window(), &wm_info);
-        HMONITOR monitor = MonitorFromWindow(wm_info.info.win.window, MONITOR_DEFAULTTONEAREST);
-        
-        MONITORINFO monitor_info;
-        monitor_info.cbSize = sizeof(monitor_info);
-        GetMonitorInfo(monitor, &monitor_info);
-        work_area = monitor_info.rcWork;
-    }
-    
-    RECT window_size = work_area;
-    // Keep in sync with STYLE_NORMAL in SDL_windowswindow.c.
-    DWORD style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX;
-    AdjustWindowRectEx(&window_size, style, FALSE, 0);
-    
-    // Because AdjustWindowRectEx will make our rect larger, not smaller, we need to perform some
-    // unintuitive math here.
-    SIZE size;
-    size.cx = 2 * (work_area.right - work_area.left) - (window_size.right - window_size.left);
-    size.cy = 2 * (work_area.bottom - work_area.top) - (window_size.bottom - window_size.top);
-    return size;
-}
-
-int Gosu::available_width(Window* window)
-{
-    return max_window_size(window).cx;
-}
-
-int Gosu::available_height(Window* window)
-{
-    return max_window_size(window).cy;
-}
-#endif
-
-#ifdef GOSU_IS_X
-// Pessimistic fallback implementation for available_width / available_height.
-// TODO: Look at this NET_WORKAREA based implementation: https://github.com/glfw/glfw/pull/989/files
-int Gosu::available_width(Window* window)
-{
-    return static_cast<unsigned>(Gosu::screen_width(window) * 0.9);
-}
-
-int Gosu::available_height(Window* window)
-{
-    return static_cast<unsigned>(Gosu::screen_height(window) * 0.8);
-}
-#endif
-
 #endif

--- a/src/Resolution.cpp
+++ b/src/Resolution.cpp
@@ -84,52 +84,52 @@ static SDL_Rect max_window_size(Gosu::Window* window)
     SDL_Rect rect;
     SDL_GetDisplayUsableBounds(index, &rect);
 
-	if (window) {
-	    SDL_SysWMinfo info;
-	    SDL_VERSION(&info.version);
-	    SDL_GetWindowWMInfo(Gosu::shared_window(), &info);
-	    HWND hwnd = info.info.win.window;
+    if (window) {
+        SDL_SysWMinfo info;
+        SDL_VERSION(&info.version);
+        SDL_GetWindowWMInfo(Gosu::shared_window(), &info);
+        HWND hwnd = info.info.win.window;
 
-	    RECT rcClient, rcWindow;
-	    POINT ptDiff;
-	    int top = 0, left = 0, bottom = 0, right = 0;
+        RECT rcClient, rcWindow;
+        POINT ptDiff;
+        int top = 0, left = 0, bottom = 0, right = 0;
 
-	    /* rcClient stores the size of the inner window, while rcWindow stores the outer size relative to the top-left
-	     * screen position; so the top/left values of rcClient are always {0,0} and bottom/right are {height,width} */
-	    GetClientRect(hwnd, &rcClient);
-	    DwmGetWindowAttribute(hwnd, DWMWA_EXTENDED_FRAME_BOUNDS, &rcWindow, sizeof(rcWindow));
+        /* rcClient stores the size of the inner window, while rcWindow stores the outer size relative to the top-left
+         * screen position; so the top/left values of rcClient are always {0,0} and bottom/right are {height,width} */
+        GetClientRect(hwnd, &rcClient);
+        DwmGetWindowAttribute(hwnd, DWMWA_EXTENDED_FRAME_BOUNDS, &rcWindow, sizeof(rcWindow));
 
-	    /* convert the top/left values to make them relative to
-	     * the window; they will end up being slightly negative */
-	    ptDiff.y = rcWindow.top;
-	    ptDiff.x = rcWindow.left;
+        /* convert the top/left values to make them relative to
+         * the window; they will end up being slightly negative */
+        ptDiff.y = rcWindow.top;
+        ptDiff.x = rcWindow.left;
 
-	    ScreenToClient(hwnd, &ptDiff);
+        ScreenToClient(hwnd, &ptDiff);
 
-	    rcWindow.top = ptDiff.y;
-	    rcWindow.left = ptDiff.x;
+        rcWindow.top = ptDiff.y;
+        rcWindow.left = ptDiff.x;
 
-	    /* convert the bottom/right values to make them relative to the window,
-	     * these will be slightly bigger than the inner width/height */
-	    ptDiff.y = rcWindow.bottom;
-	    ptDiff.x = rcWindow.right;
+        /* convert the bottom/right values to make them relative to the window,
+         * these will be slightly bigger than the inner width/height */
+        ptDiff.y = rcWindow.bottom;
+        ptDiff.x = rcWindow.right;
 
-	    ScreenToClient(hwnd, &ptDiff);
+        ScreenToClient(hwnd, &ptDiff);
 
-	    rcWindow.bottom = ptDiff.y;
-	    rcWindow.right = ptDiff.x;
+        rcWindow.bottom = ptDiff.y;
+        rcWindow.right = ptDiff.x;
 
-	    /* Now that both the inner and outer rects use the same coordinate system we can substract them to get the border size.
-	     * Keep in mind that the top/left coordinates of rcWindow are negative because the border lies slightly before {0,0},
-	     * so switch them around because SDL2 wants them in positive. */
-	    top = rcClient.top - rcWindow.top;
-	    left = rcClient.left - rcWindow.left;
-	    bottom = rcWindow.bottom - rcClient.bottom;
-	    right = rcWindow.right - rcClient.right;
+        /* Now that both the inner and outer rects use the same coordinate system we can substract them to get the border size.
+         * Keep in mind that the top/left coordinates of rcWindow are negative because the border lies slightly before {0,0},
+         * so switch them around because SDL2 wants them in positive. */
+        top = rcClient.top - rcWindow.top;
+        left = rcClient.left - rcWindow.left;
+        bottom = rcWindow.bottom - rcClient.bottom;
+        right = rcWindow.right - rcClient.right;
 
-	    rect.w -= left + right;
-	    rect.h -= top + bottom;
-	}
+        rect.w -= left + right;
+        rect.h -= top + bottom;
+    }
 
     // Return a rect to have one less Gosu::available_width/height implementation.
     return rect;

--- a/src/Resolution.cpp
+++ b/src/Resolution.cpp
@@ -40,7 +40,7 @@ static NSSize max_window_size(Gosu::Window* window)
         style = NSWindowStyleMaskBorderless;
     }
     else {
-        style = (NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable);
+        style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable;
     }
     if (window && window->resizable()) {
         style |= NSWindowStyleMaskResizable;
@@ -48,7 +48,7 @@ static NSSize max_window_size(Gosu::Window* window)
 
     auto index = window ? SDL_GetWindowDisplayIndex(Gosu::shared_window()) : 0;
     auto screen_frame = NSScreen.screens[index].visibleFrame;
-    return[NSWindow contentRectForFrameRect : screen_frame styleMask : style].size;
+    return [NSWindow contentRectForFrameRect:screen_frame styleMask:style].size;
 }
 
 int Gosu::available_width(Window* window)

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -174,6 +174,8 @@ void Gosu::Window::resize(int width, int height, bool fullscreen)
             // If the window is resizable, don't perform hidden scaling or resizing.
             width  = actual_width  = min(width,  max_width);
             height = actual_height = min(height, max_height);
+
+            printf("RESIZER: Max Width: %d, Max Height: %d\n", max_width, max_height);
         }
         else if (width > max_width || height > max_height) {
             // If the window cannot fit on the screen, shrink its contents.
@@ -206,7 +208,10 @@ void Gosu::Window::resize(int width, int height, bool fullscreen)
     pimpl->input->set_mouse_factors(1 / scale_factor, 1 / scale_factor,
                                     black_bar_width, black_bar_height);
 
-    printf("RESIZE: scale_factor: %f, width: %d, height: %d, actual_width: %d, actual_height: %d, window_width: %d, window_height: %d\n", scale_factor, width, height, actual_width, actual_height, Gosu::Window::width(), Gosu::Window::height());
+    printf("RESIZE: scale_factor: %f, width: %d, height: %d, actual_width: %d, actual_height: %d, "
+           "window_width: %d, window_height: %d\n",
+           scale_factor, width, height, actual_width, actual_height, Gosu::Window::width(),
+           Gosu::Window::height());
 }
 
 bool Gosu::Window::resizable() const

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -93,8 +93,6 @@ Gosu::Window::Window(int width, int height, unsigned window_flags, double update
     set_borderless(window_flags & WF_BORDERLESS);
     set_resizable(window_flags & WF_RESIZABLE);
 
-    pimpl->resizable = resizable;
-
     // Even in fullscreen mode, temporarily show the window in windowed mode to centre it.
     // This ensures that the window will be centered correctly when exiting fullscreen mode.
     // Fixes https://github.com/gosu/gosu/issues/369

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -171,11 +171,9 @@ void Gosu::Window::resize(int width, int height, bool fullscreen)
         int max_height = Gosu::available_height(this);
 
         if (resizable()) {
-            // If the window is resizable, don't perform hidden scaling or resizing.
+            // If the window is resizable, limit its size, without preserving the aspect ratio.
             width  = actual_width  = min(width,  max_width);
             height = actual_height = min(height, max_height);
-
-            printf("RESIZER: Max Width: %d, Max Height: %d\n", max_width, max_height);
         }
         else if (width > max_width || height > max_height) {
             // If the window cannot fit on the screen, shrink its contents.
@@ -207,11 +205,6 @@ void Gosu::Window::resize(int width, int height, bool fullscreen)
     }
     pimpl->input->set_mouse_factors(1 / scale_factor, 1 / scale_factor,
                                     black_bar_width, black_bar_height);
-
-    printf("RESIZE: scale_factor: %f, width: %d, height: %d, actual_width: %d, actual_height: %d, "
-           "window_width: %d, window_height: %d\n",
-           scale_factor, width, height, actual_width, actual_height, Gosu::Window::width(),
-           Gosu::Window::height());
 }
 
 bool Gosu::Window::resizable() const

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -93,6 +93,8 @@ Gosu::Window::Window(int width, int height, unsigned window_flags, double update
     set_borderless(window_flags & WF_BORDERLESS);
     set_resizable(window_flags & WF_RESIZABLE);
 
+    pimpl->resizable = resizable;
+
     // Even in fullscreen mode, temporarily show the window in windowed mode to centre it.
     // This ensures that the window will be centered correctly when exiting fullscreen mode.
     // Fixes https://github.com/gosu/gosu/issues/369
@@ -171,9 +173,7 @@ void Gosu::Window::resize(int width, int height, bool fullscreen)
         int max_height = Gosu::available_height(this);
 
         if (resizable()) {
-            // If the window is resizable, limit its size, without preserving the aspect ratio.
-            width  = actual_width  = min(width,  max_width);
-            height = actual_height = min(height, max_height);
+            // If the window is resizable, don't perform hidden scaling or resizing.
         }
         else if (width > max_width || height > max_height) {
             // If the window cannot fit on the screen, shrink its contents.

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -172,6 +172,8 @@ void Gosu::Window::resize(int width, int height, bool fullscreen)
 
         if (resizable()) {
             // If the window is resizable, don't perform hidden scaling or resizing.
+            width  = actual_width  = min(width,  max_width);
+            height = actual_height = min(height, max_height);
         }
         else if (width > max_width || height > max_height) {
             // If the window cannot fit on the screen, shrink its contents.
@@ -203,6 +205,8 @@ void Gosu::Window::resize(int width, int height, bool fullscreen)
     }
     pimpl->input->set_mouse_factors(1 / scale_factor, 1 / scale_factor,
                                     black_bar_width, black_bar_height);
+
+    printf("RESIZE: scale_factor: %f, width: %d, height: %d, actual_width: %d, actual_height: %d, window_width: %d, window_height: %d\n", scale_factor, width, height, actual_width, actual_height, Gosu::Window::width(), Gosu::Window::height());
 }
 
 bool Gosu::Window::resizable() const

--- a/windows/Gosu.vcxproj
+++ b/windows/Gosu.vcxproj
@@ -107,7 +107,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Lib>
-      <AdditionalDependencies>SDL2.lib;opengl32.lib;openal32.lib;winmm.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>SDL2.lib;opengl32.lib;openal32.lib;winmm.lib;dwmapi.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <AdditionalLibraryDirectories>$(SDL2_LIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Lib>
@@ -127,7 +127,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Lib>
-      <AdditionalDependencies>SDL2.lib;opengl32.lib;openal32.lib;winmm.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>SDL2.lib;opengl32.lib;openal32.lib;winmm.lib;dwmapi.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <AdditionalLibraryDirectories>$(SDL2_LIB64);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Lib>
@@ -146,7 +146,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Lib>
-      <AdditionalDependencies>SDL2.lib;opengl32.lib;openal32.lib;winmm.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>SDL2.lib;opengl32.lib;openal32.lib;winmm.lib;dwmapi.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SDL2_LIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Lib>
   </ItemDefinitionGroup>
@@ -166,7 +166,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Lib>
-      <AdditionalDependencies>SDL2.lib;opengl32.lib;openal32.lib;winmm.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>SDL2.lib;opengl32.lib;openal32.lib;winmm.lib;dwmapi.lib;delayimp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SDL2_LIB64);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Lib>
   </ItemDefinitionGroup>


### PR DESCRIPTION
Move `pimpl->resizable = resizable` to above first call to `resize`. Fixes oversized windows becoming smaller.

Removed `min(width/height, max_width/height)`. May fix scaling weirdness. #497