### PR TITLE
Fix multiple gamepads at launch

### DIFF
--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -159,6 +159,7 @@ struct Gosu::Input::Impl
                         );
                         gamepad_slot = available_gamepad_slot_index();
                         device_instance_id = SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(game_controller));
+                        printf("Controller connected [%i]: %s\n", e->jdevice.which, SDL_GameControllerNameForIndex(e->jdevice.which));
                     }
                 }
                 // ...but fall back on the good, old SDL_Joystick API.

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -159,8 +159,9 @@ struct Gosu::Input::Impl
                         if (SDL_GameController *game_controller = SDL_GameControllerOpen(i)) {
                             gamepad_slot = available_gamepad_slot_index();
                             joystick_instance_id = SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(game_controller));
-                            if (gamepad_instance_id_is_known(joystick_instance_id))
+                            if (gamepad_instance_id_is_known(joystick_instance_id)) {
                                 continue;
+                            }
                             open_game_controllers.emplace_back(
                                 shared_ptr<SDL_GameController>(game_controller, SDL_GameControllerClose)
                             );
@@ -170,8 +171,9 @@ struct Gosu::Input::Impl
                     else if (SDL_Joystick *joystick = SDL_JoystickOpen(i)) {
                         gamepad_slot = available_gamepad_slot_index();
                         joystick_instance_id = SDL_JoystickInstanceID(joystick);
-                        if (gamepad_instance_id_is_known(joystick_instance_id))
+                        if (gamepad_instance_id_is_known(joystick_instance_id)) {
                             continue;
+                        }
                         open_joysticks.emplace_back(
                             shared_ptr<SDL_Joystick>(joystick, SDL_JoystickClose)
                         );


### PR DESCRIPTION
If multiple gamepads are present at launch (and maybe if connected simultaneously) the first gamepad is opened again instead instead of the correct gamepad.
This causes the first gamepad to be "cloned" and screws up the `gamepad_slot` system.
Since the `Joystick Instance ID` is the same for the clones which is checked when removing a gamepad, this causes gamepads to be orphaned.

Cause: `e->jdevice.which` appears to always be `0` (SDL Device ID)

This PR eagerly tries to connect to every available gamepad when a new gamepad is connected, ignoring already connected gamepads.