### PR TITLE
Compatibility fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # - Prefer static libraries. Users should link Gosu into their games.
 # - This is not (yet?) going to be used for building Ruby/Gosu.
 # - This is not (yet?) going to replace the Visual Studio project for Windows.
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.18.4)
 
 project(Gosu VERSION 0.15.2)
 
@@ -21,8 +21,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(SDL2 REQUIRED)
 find_package(OpenAL REQUIRED)
-# Prefer glvnd (the "GL Vendor-Neutral Dispatch library") over plain libGL.so.
-cmake_policy(SET CMP0072 NEW)
 find_package(OpenGL REQUIRED)
 
 if(APPLE)

--- a/include/Gosu/Image.hpp
+++ b/include/Gosu/Image.hpp
@@ -48,7 +48,7 @@ namespace Gosu
         unsigned height() const;
 
         //! Draws the image so its upper left corner is at (x; y).
-        void draw(double x, double y, ZPos z, double scale_x = 1, double scale_y = 1,
+        void draw(double x, double y, ZPos z = 0, double scale_x = 1, double scale_y = 1,
             Color c = Color::WHITE, AlphaMode mode = AM_DEFAULT) const;
         //! Like draw(), but with modulation colors for all four corners.
         void draw_mod(double x, double y, ZPos z, double scale_x, double scale_y,
@@ -63,7 +63,7 @@ namespace Gosu
         //! on the image. 0 is the left border, 1 is the right border, 0.5 is
         //! the center (and default).
         //! \param center_y See center_x.
-        void draw_rot(double x, double y, ZPos z, double angle,
+        void draw_rot(double x, double y, ZPos z = 0, double angle = 0,
             double center_x = 0.5, double center_y = 0.5, double scale_x = 1, double scale_y = 1,
             Color c = Color::WHITE, AlphaMode mode = AM_DEFAULT) const;
         

--- a/rdoc/gosu.rb
+++ b/rdoc/gosu.rb
@@ -475,7 +475,7 @@ module Gosu
     # @see #draw_as_quad
     # @see https://github.com/gosu/gosu/wiki/Basic-Concepts#drawing-with-colours Drawing with colors, explained in the Gosu Wiki
     # @see https://github.com/gosu/gosu/wiki/Basic-Concepts#z-ordering Z-ordering explained in the Gosu Wiki
-    def draw(x, y, z, scale_x=1, scale_y=1, color=0xff_ffffff, mode=:default); end
+    def draw(x, y, z=0, scale_x=1, scale_y=1, color=0xff_ffffff, mode=:default); end
 
     ##
     # Draws the image rotated, with its rotational center at (x, y).
@@ -489,7 +489,7 @@ module Gosu
     # @see #draw
     # @see https://github.com/gosu/gosu/wiki/Basic-Concepts#drawing-with-colours Drawing with colors, explained in the Gosu Wiki
     # @see https://github.com/gosu/gosu/wiki/Basic-Concepts#z-ordering Z-ordering explained in the Gosu Wiki
-    def draw_rot(x, y, z, angle, center_x=0.5, center_y=0.5, scale_x=1, scale_y=1, color=0xff_ffffff, mode=:default); end
+    def draw_rot(x, y, z=0, angle=0, center_x=0.5, center_y=0.5, scale_x=1, scale_y=1, color=0xff_ffffff, mode=:default); end
 
     ##
     # Draws the image as an arbitrary quad. This method can be used for advanced non-rectangular drawing techniques, e.g., faking perspective or isometric projection.

--- a/src/RubyGosu.cxx
+++ b/src/RubyGosu.cxx
@@ -6211,7 +6211,7 @@ _wrap_Image_draw(int argc, VALUE *argv, VALUE self) {
   Gosu::Image *arg1 = (Gosu::Image *) 0 ;
   double arg2 ;
   double arg3 ;
-  Gosu::ZPos arg4 ;
+  Gosu::ZPos arg4 = (Gosu::ZPos) 0 ;
   double arg5 = (double) 1 ;
   double arg6 = (double) 1 ;
   Gosu::Color arg7 = (Gosu::Color) Gosu::Color::WHITE ;
@@ -6229,8 +6229,8 @@ _wrap_Image_draw(int argc, VALUE *argv, VALUE self) {
   double val6 ;
   int ecode6 = 0 ;
   
-  if ((argc < 3) || (argc > 7)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 3)",argc); SWIG_fail;
+  if ((argc < 2) || (argc > 7)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
   }
   res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_Gosu__Image, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
@@ -6247,11 +6247,13 @@ _wrap_Image_draw(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "double","draw", 3, argv[1] ));
   } 
   arg3 = static_cast< double >(val3);
-  ecode4 = SWIG_AsVal_double(argv[2], &val4);
-  if (!SWIG_IsOK(ecode4)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode4), Ruby_Format_TypeError( "", "Gosu::ZPos","draw", 4, argv[2] ));
-  } 
-  arg4 = static_cast< Gosu::ZPos >(val4);
+  if (argc > 2) {
+    ecode4 = SWIG_AsVal_double(argv[2], &val4);
+    if (!SWIG_IsOK(ecode4)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode4), Ruby_Format_TypeError( "", "Gosu::ZPos","draw", 4, argv[2] ));
+    } 
+    arg4 = static_cast< Gosu::ZPos >(val4);
+  }
   if (argc > 3) {
     ecode5 = SWIG_AsVal_double(argv[3], &val5);
     if (!SWIG_IsOK(ecode5)) {
@@ -6488,8 +6490,8 @@ _wrap_Image_draw_rot(int argc, VALUE *argv, VALUE self) {
   Gosu::Image *arg1 = (Gosu::Image *) 0 ;
   double arg2 ;
   double arg3 ;
-  Gosu::ZPos arg4 ;
-  double arg5 ;
+  Gosu::ZPos arg4 = (Gosu::ZPos) 0 ;
+  double arg5 = (double) 0 ;
   double arg6 = (double) 0.5 ;
   double arg7 = (double) 0.5 ;
   double arg8 = (double) 1 ;
@@ -6515,8 +6517,8 @@ _wrap_Image_draw_rot(int argc, VALUE *argv, VALUE self) {
   double val9 ;
   int ecode9 = 0 ;
   
-  if ((argc < 4) || (argc > 10)) {
-    rb_raise(rb_eArgError, "wrong # of arguments(%d for 4)",argc); SWIG_fail;
+  if ((argc < 2) || (argc > 10)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
   }
   res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_Gosu__Image, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
@@ -6533,16 +6535,20 @@ _wrap_Image_draw_rot(int argc, VALUE *argv, VALUE self) {
     SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "double","draw_rot", 3, argv[1] ));
   } 
   arg3 = static_cast< double >(val3);
-  ecode4 = SWIG_AsVal_double(argv[2], &val4);
-  if (!SWIG_IsOK(ecode4)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode4), Ruby_Format_TypeError( "", "Gosu::ZPos","draw_rot", 4, argv[2] ));
-  } 
-  arg4 = static_cast< Gosu::ZPos >(val4);
-  ecode5 = SWIG_AsVal_double(argv[3], &val5);
-  if (!SWIG_IsOK(ecode5)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode5), Ruby_Format_TypeError( "", "double","draw_rot", 5, argv[3] ));
-  } 
-  arg5 = static_cast< double >(val5);
+  if (argc > 2) {
+    ecode4 = SWIG_AsVal_double(argv[2], &val4);
+    if (!SWIG_IsOK(ecode4)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode4), Ruby_Format_TypeError( "", "Gosu::ZPos","draw_rot", 4, argv[2] ));
+    } 
+    arg4 = static_cast< Gosu::ZPos >(val4);
+  }
+  if (argc > 3) {
+    ecode5 = SWIG_AsVal_double(argv[3], &val5);
+    if (!SWIG_IsOK(ecode5)) {
+      SWIG_exception_fail(SWIG_ArgError(ecode5), Ruby_Format_TypeError( "", "double","draw_rot", 5, argv[3] ));
+    } 
+    arg5 = static_cast< double >(val5);
+  }
   if (argc > 4) {
     ecode6 = SWIG_AsVal_double(argv[4], &val6);
     if (!SWIG_IsOK(ecode6)) {


### PR DESCRIPTION
* Makes some Image#draw arguments optional again, for compatibility with older games
* Don't set CMP0072, which was only introduced in CMake 3.11 (Gosu only requires 3.10); instead, confirm that we agree with all policy changes inbetween CMake 3.10 and 3.18.4: https://cmake.org/cmake/help/git-stage/command/cmake_policy.html#setting-policies-by-cmake-version