### PR TITLE
Merge Song & Sample (Audio 3.0, supersedes #441)

### DIFF
--- a/examples/Tutorial-Touch/Tutorial-Touch.cpp
+++ b/examples/Tutorial-Touch/Tutorial-Touch.cpp
@@ -62,7 +62,7 @@ public:
 class Player
 {
     Gosu::Image image;
-    Gosu::Sample beep;
+    Gosu::Sound beep;
     double pos_x, pos_y, vel_x, vel_y, angle;
     unsigned score;
 

--- a/examples/Tutorial/Tutorial.cpp
+++ b/examples/Tutorial/Tutorial.cpp
@@ -61,7 +61,7 @@ public:
 class Player
 {
     Gosu::Image image;
-    Gosu::Sample beep;
+    Gosu::Sound beep;
     double pos_x, pos_y, vel_x, vel_y, angle;
     unsigned score;
 

--- a/ext/gosu/gosu.i
+++ b/ext/gosu/gosu.i
@@ -987,9 +987,9 @@ namespace Gosu
 %ignore Gosu::Channel::Channel();
 %ignore Gosu::Channel::Channel(int, int);
 %ignore Gosu::Channel::current_channel();
-%ignore Gosu::Sample::Sample();
-%ignore Gosu::Sample::Sample(Reader reader);
 %ignore Gosu::Song::Song(Reader reader);
+%ignore Gosu::Sound::Sound();
+%ignore Gosu::Sound::Sound(Reader reader);
 %rename("playing?") playing;
 %rename("paused?") paused;
 %rename("volume=") set_volume;

--- a/ffi/Gosu_FFI_internal.h
+++ b/ffi/Gosu_FFI_internal.h
@@ -43,9 +43,9 @@ struct Gosu_Image
     Gosu::Image image;
 };
 
-struct Gosu_Sample
+struct Gosu_Sound
 {
-    Gosu::Sample sample;
+    Gosu::Sound sound;
 };
 
 // Use inheritance where composition is not feasible

--- a/ffi/Gosu_Sample.cpp
+++ b/ffi/Gosu_Sample.cpp
@@ -1,31 +1,31 @@
 #include "Gosu_FFI_internal.h"
 
-GOSU_FFI_API Gosu_Sample* Gosu_Sample_create(const char* filename)
+GOSU_FFI_API Gosu_Sound* Gosu_Sound_create(const char* filename)
 {
-    return Gosu_translate_exceptions([=] {
-        return new Gosu_Sample{Gosu::Sample{filename}};
+    return Gosu_translate_exceptions([=] { //
+        return new Gosu_Sound{Gosu::Sound{filename}};
     });
 }
 
-GOSU_FFI_API void Gosu_Sample_destroy(Gosu_Sample* sample)
+GOSU_FFI_API void Gosu_Sound_destroy(Gosu_Sound* sound)
 {
-    Gosu_translate_exceptions([=] {
-        delete sample;
+    Gosu_translate_exceptions([=] { //
+        delete sound;
     });
 }
 
-GOSU_FFI_API Gosu_Channel* Gosu_Sample_play(Gosu_Sample* sample, double volume, double speed,
-                                            bool looping)
+GOSU_FFI_API Gosu_Channel* Gosu_Sound_play(Gosu_Sound* sound, double volume, double speed,
+                                           bool looping)
 {
-    return Gosu_translate_exceptions([=] {
-        return new Gosu_Channel{sample->sample.play(volume, speed, looping)};
+    return Gosu_translate_exceptions([=] { //
+        return new Gosu_Channel{sound->sound.play(volume, speed, looping)};
     });
 }
 
-GOSU_FFI_API Gosu_Channel* Gosu_Sample_play_pan(Gosu_Sample* sample, double pan, double volume,
-                                                double speed, bool looping)
+GOSU_FFI_API Gosu_Channel* Gosu_Sound_play_pan(Gosu_Sound* sound, double pan, double volume,
+                                               double speed, bool looping)
 {
-    return Gosu_translate_exceptions([=] {
-        return new Gosu_Channel{sample->sample.play_pan(pan, volume, speed, looping)};
+    return Gosu_translate_exceptions([=] { //
+        return new Gosu_Channel{sound->sound.play_pan(pan, volume, speed, looping)};
     });
 }

--- a/ffi/Gosu_Sample.h
+++ b/ffi/Gosu_Sample.h
@@ -3,12 +3,12 @@
 #include "Gosu_Channel.h"
 #include "Gosu_FFI.h"
 
-typedef struct Gosu_Sample Gosu_Sample;
+typedef struct Gosu_Sound Gosu_Sample;
 
-GOSU_FFI_API Gosu_Sample* Gosu_Sample_create(const char* filename);
-GOSU_FFI_API void Gosu_Sample_destroy(Gosu_Sample* sample);
+GOSU_FFI_API Gosu_Sound* Gosu_Sound_create(const char* filename);
+GOSU_FFI_API void Gosu_Sound_destroy(Gosu_Sound* sound);
 
-GOSU_FFI_API Gosu_Channel* Gosu_Sample_play(Gosu_Sample* sample, double volume, double speed,
-                                            bool looping);
-GOSU_FFI_API Gosu_Channel* Gosu_Sample_play_pan(Gosu_Sample* sample, double pan, double volume,
-                                                double speed, bool looping);
+GOSU_FFI_API Gosu_Channel* Gosu_Sound_play(Gosu_Sound* sound, double volume, double speed,
+                                           bool looping);
+GOSU_FFI_API Gosu_Channel* Gosu_Sound_play_pan(Gosu_Sound* sound, double pan, double volume,
+                                               double speed, bool looping);

--- a/include/Gosu/Audio.hpp
+++ b/include/Gosu/Audio.hpp
@@ -9,7 +9,7 @@
 
 namespace Gosu
 {
-    /// Sample::play returns a Channel that represents the sound being played.
+    /// Sound::play returns a Channel that represents the sound being played.
     /// This object can be used to stop or influence sounds as they are played, or to check whether
     /// playback has finished.
     class Channel
@@ -28,11 +28,11 @@ namespace Gosu
         bool playing() const;
         bool paused() const;
         /// Pauses this instance to be resumed afterwards.
-        /// Avoid leaving samples paused for too long, as they will still occupy one of Gosu's
+        /// Avoid leaving sounds paused for too long, as they will still occupy one of Gosu's
         /// limited channels.
         void pause();
         void resume();
-        /// Stops this m_channel if the sample is still being played.
+        /// Stops this m_channel if the sounds is still being played.
         /// If this method is called when playback has finished, it has no effect.
         void stop();
 
@@ -44,34 +44,33 @@ namespace Gosu
         void set_speed(double speed);
     };
 
-    /// A sample is a short sound that is completely loaded in memory, can be played multiple times
+    /// A sounds is a short sound that is completely loaded in memory, can be played multiple times
     /// at once, and offers very flexible playback parameters.
-    class Sample
+    class Sound
     {
         struct Impl;
         std::shared_ptr<Impl> m_impl;
 
     public:
-        /// Constructs an empty sample that is inaudible when played.
-        Sample();
+        /// Constructs an empty sound that is inaudible when played.
+        Sound();
 
-        /// Constructs a sample that can be played on the specified audio
-        /// system and loads the sample from a file.
-        explicit Sample(const std::string& filename);
+        /// Constructs a sound that can be played on the specified audio
+        /// system and loads the sound from a file.
+        explicit Sound(const std::string& filename);
 
-        /// Constructs a sample that can be played on the specified audio
-        /// system and loads the sample data from a stream.
-        explicit Sample(Reader reader);
+        /// Constructs a sound that can be played on the specified audio
+        /// system and loads the sound data from a stream.
+        explicit Sound(Reader reader);
 
-        /// Plays the sample without panning.
+        /// Plays the sound without panning.
         /// @param volume Can be anything from 0.0 (silence) to 1.0 (full volume).
         /// @param speed Playback speed is only limited by the underlying audio library,
         ///              and can accept very high or low values. Use 1.0 for normal playback speed.
         Channel play(double volume = 1.0, double speed = 1.0, bool looping = false) const;
 
-        /// Plays the sample with panning. Even if pan is 0.0, the sample will
-        /// not be as loud as if it were played by calling play() due to the
-        /// way the panning works.
+        /// Plays the sound with panning. Even if pan is 0.0, the sound will not be as loud as if it
+        /// were played by calling play() due to the way the panning works.
         /// @param pan Can be anything from -1.0 (left) to 1.0 (right).
         /// @param volume Can be anything from 0.0 (silence) to 1.0 (full volume).
         /// @param speed Playback speed is only limited by by the underlying audio library,
@@ -80,7 +79,7 @@ namespace Gosu
                          bool looping = false) const;
     };
 
-    /// Songs are less flexible than Samples. Only one Song can be played at any given time,
+    /// Songs are less flexible than Sounds. Only one Song can be played at any given time,
     /// and there is no way to control its pan (stereo position) or speed.
     class Song : private Noncopyable
     {

--- a/include/Gosu/Fwd.hpp
+++ b/include/Gosu/Fwd.hpp
@@ -14,8 +14,8 @@ namespace Gosu
     class Input;
     class Reader;
     class Resource;
-    class Sample;
     class Song;
+    class Sound;
     class TextInput;
     class Window;
     class Writer;

--- a/lib/gosu/compat.rb
+++ b/lib/gosu/compat.rb
@@ -170,6 +170,10 @@ module Gosu
   SampleInstance = Channel
   deprecate_constant :SampleInstance
 
+  # Sound was called Sample before Gosu 1.4.0.
+  Sample = Sound
+  deprecate_constant :Sample
+
   # Support for KbLeft instead of KB_LEFT and Gp3Button2 instead of GP_3_BUTTON_2.
   Gosu.constants.grep(/^KB_|MS_|GP_/).each do |new_name|
     old_name = case new_name

--- a/rdoc/gosu.rb
+++ b/rdoc/gosu.rb
@@ -550,49 +550,49 @@ module Gosu
   end
 
   ##
-  # A sample is a short sound that is completely loaded in memory, can be
+  # A sound is a short sound that is completely loaded in memory, can be
   # played multiple times at once and offers very flexible playback
   # parameters. Use samples for everything that's not music.
   #
   # @see Gosu::Song
-  class Sample
+  class Sound
     ##
-    # Loads a sample from a file.
+    # Loads a sound from a file.
     #
     # (Passing a Window reference is not necessary anymore, please use the first overload from now on.)
     #
     # @overload initialize(filename)
     # @overload initialize(window, filename)
     #
-    # @param filename [String] the path to load the sample from.
+    # @param filename [String] the path to load the sound from.
     def initialize(filename); end
 
     ##
-    # Plays the sample without panning.
+    # Plays the sound without panning.
     #
     # @return [Channel]
     # @param volume [Float] see {Channel#volume=}
     # @param speed [Float] see {Channel#speed=}
-    # @param looping [true, false] whether the sample should play in a loop. If you pass true, be sure to store the return value of this method so that you can later stop the looping sound.
+    # @param looping [true, false] whether the sound should play in a loop. If you pass true, be sure to store the return value of this method so that you can later stop the looping sound.
     #
     # @see #play_pan
     def play(volume=1, speed=1, looping=false); end
 
     ##
-    # Plays the sample with panning.
+    # Plays the sound with panning.
     #
     # @return [Channel]
     # @param pan [Float] see {Channel#pan=}
     # @param volume [Float] see {Channel#volume=}
     # @param speed [Float] see {Channel#speed=}
-    # @param looping [true, false] whether the sample should play in a loop. If you pass true, be sure to store the return value of this method so that you can later stop the looping sound.
+    # @param looping [true, false] whether the sound should play in a loop. If you pass true, be sure to store the return value of this method so that you can later stop the looping sound.
     #
     # @see #play
     def play_pan(pan=0, volume=1, speed=1, looping=false); end
   end
 
   ##
-  # {Sample#play} returns a Channel that represents the sound currently being played.
+  # {Sound#play} returns a Channel that represents the sound currently being played.
   #
   # This object can be used to stop sounds dynamically, or to check whether they have finished.
   class Channel
@@ -603,7 +603,7 @@ module Gosu
     attr_writer :volume
 
     ##
-    # Sets the playback speed. A value of 2.0 will play the sample at 200% speed and one octave higher. A value of 0.5 will play the sample at 50% speed and one octave lower. The valid range of this property depends on the operating system, but values up to 8.0 should work.
+    # Sets the playback speed. A value of 2.0 will play the sound at 200% speed and one octave higher. A value of 0.5 will play the sound at 50% speed and one octave lower. The valid range of this property depends on the operating system, but values up to 8.0 should work.
     # @param [Float]
     # @return [Float]
     attr_writer :speed
@@ -615,40 +615,40 @@ module Gosu
     attr_writer :pan
 
     ##
-    # Stops playback of this sample instance. After calling this method, the sample instance is useless and can be discarded.
+    # Stops playback of this sound instance. After calling this method, the sound instance is useless and can be discarded.
     #
-    # Calling `stop` after the sample has finished is harmless and has no effect.
+    # Calling `stop` after the sound has finished is harmless and has no effect.
     #
     # @return [void]
     def stop; end
 
     ##
-    # Pauses the sample, to be resumed afterwards.
+    # Pauses the sound, to be resumed afterwards.
     #
-    # @note The sample will still occupy a playback channel while paused.
+    # @note The sound will still occupy a playback channel while paused.
     #
     # @return [void]
     def pause; end
 
     ##
-    # Resumes playback of the sample.
+    # Resumes playback of the sound.
     #
     # @return [void]
     def resume; end
 
     ##
-    # @return [true, false] whether the sample is paused.
+    # @return [true, false] whether the sound is paused.
     def paused?; end
 
     ##
-    # @return [true, false] whether the sample is playing.
+    # @return [true, false] whether the sound is playing.
     def playing?; end
   end
 
   ##
   # Songs are less flexible than samples in that only one can be played at a time, with no panning or speed control.
   #
-  # @see Gosu::Sample
+  # @see Gosu::Sound
   class Song
     class <<Song
       ##

--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -13,7 +13,7 @@ static Gosu::Song* cur_song = nullptr;
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static bool cur_song_looping;
 
-struct Gosu::Sample::Impl
+struct Gosu::Sound::Impl
 {
     ALuint buffer;
 
@@ -37,26 +37,26 @@ struct Gosu::Sample::Impl
     }
 };
 
-Gosu::Sample::Sample()
+Gosu::Sound::Sound()
 {
 }
 
-Gosu::Sample::Sample(const std::string& filename)
+Gosu::Sound::Sound(const std::string& filename)
 : m_impl{new Impl(AudioFile(filename))}
 {
 }
 
-Gosu::Sample::Sample(Gosu::Reader reader)
+Gosu::Sound::Sound(Gosu::Reader reader)
 : m_impl{new Impl(AudioFile(reader))}
 {
 }
 
-Gosu::Channel Gosu::Sample::play(double volume, double speed, bool looping) const
+Gosu::Channel Gosu::Sound::play(double volume, double speed, bool looping) const
 {
     return play_pan(0.0, volume, speed, looping);
 }
 
-Gosu::Channel Gosu::Sample::play_pan(double pan, double volume, double speed, bool looping) const
+Gosu::Channel Gosu::Sound::play_pan(double pan, double volume, double speed, bool looping) const
 {
     if (!m_impl) return Channel{};
 

--- a/src/AudioImpl.cpp
+++ b/src/AudioImpl.cpp
@@ -53,7 +53,7 @@ Gosu::Channel Gosu::allocate_channel()
 
     // Start looking at index 1 to keep one free channel for songs.
     for (int i = 1; i < CHANNELS; ++i) {
-        // Do not interrupt any playing or paused samples.
+        // Do not interrupt any playing or paused sounds.
         ALint state;
         alGetSourcei(_sources[i], AL_SOURCE_STATE, &state);
         if (state == AL_PLAYING || state == AL_PAUSED) continue;

--- a/src/RubyGosu.cxx
+++ b/src/RubyGosu.cxx
@@ -2179,8 +2179,8 @@ namespace Swig {
 #define SWIGTYPE_p_Gosu__Font swig_types[2]
 #define SWIGTYPE_p_Gosu__GLTexInfo swig_types[3]
 #define SWIGTYPE_p_Gosu__Image swig_types[4]
-#define SWIGTYPE_p_Gosu__Sample swig_types[5]
-#define SWIGTYPE_p_Gosu__Song swig_types[6]
+#define SWIGTYPE_p_Gosu__Song swig_types[5]
+#define SWIGTYPE_p_Gosu__Sound swig_types[6]
 #define SWIGTYPE_p_Gosu__TextInput swig_types[7]
 #define SWIGTYPE_p_Gosu__Window swig_types[8]
 #define SWIGTYPE_p_char swig_types[9]
@@ -8158,16 +8158,16 @@ free_Gosu_Channel(void *self) {
     delete arg1;
 }
 
-static swig_class SwigClassSample;
+static swig_class SwigClassSound;
 
 SWIGINTERN VALUE
 #ifdef HAVE_RB_DEFINE_ALLOC_FUNC
-_wrap_Sample_allocate(VALUE self)
+_wrap_Sound_allocate(VALUE self)
 #else
-_wrap_Sample_allocate(int argc, VALUE *argv, VALUE self)
+_wrap_Sound_allocate(int argc, VALUE *argv, VALUE self)
 #endif
 {
-  VALUE vresult = SWIG_NewClassInstance(self, SWIGTYPE_p_Gosu__Sample);
+  VALUE vresult = SWIG_NewClassInstance(self, SWIGTYPE_p_Gosu__Sound);
 #ifndef HAVE_RB_DEFINE_ALLOC_FUNC
   rb_obj_call_init(vresult, argc, argv);
 #endif
@@ -8176,11 +8176,11 @@ _wrap_Sample_allocate(int argc, VALUE *argv, VALUE self)
 
 
 SWIGINTERN VALUE
-_wrap_new_Sample(int argc, VALUE *argv, VALUE self) {
+_wrap_new_Sound(int argc, VALUE *argv, VALUE self) {
   std::string *arg1 = 0 ;
   int res1 = SWIG_OLDOBJ ;
-  const char *classname SWIGUNUSED = "Gosu::Sample";
-  Gosu::Sample *result = 0 ;
+  const char *classname SWIGUNUSED = "Gosu::Sound";
+  Gosu::Sound *result = 0 ;
   
   if ((argc < 1) || (argc > 1)) {
     rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
@@ -8189,16 +8189,16 @@ _wrap_new_Sample(int argc, VALUE *argv, VALUE self) {
     std::string *ptr = (std::string *)0;
     res1 = SWIG_AsPtr_std_string(argv[0], &ptr);
     if (!SWIG_IsOK(res1)) {
-      SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "std::string const &","Sample", 1, argv[0] )); 
+      SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "std::string const &","Sound", 1, argv[0] )); 
     }
     if (!ptr) {
-      SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "std::string const &","Sample", 1, argv[0])); 
+      SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "std::string const &","Sound", 1, argv[0])); 
     }
     arg1 = ptr;
   }
   {
     try {
-      result = (Gosu::Sample *)new Gosu::Sample((std::string const &)*arg1);
+      result = (Gosu::Sound *)new Gosu::Sound((std::string const &)*arg1);
       DATA_PTR(self) = result;
       SWIG_RubyAddTracking(result, self);
     }
@@ -8215,10 +8215,10 @@ fail:
 
 
 SWIGINTERN VALUE
-_wrap_Sample_play(int argc, VALUE *argv, VALUE self) {
-  Gosu::Sample *arg1 = (Gosu::Sample *) 0 ;
-  double arg2 = (double) 1 ;
-  double arg3 = (double) 1 ;
+_wrap_Sound_play(int argc, VALUE *argv, VALUE self) {
+  Gosu::Sound *arg1 = (Gosu::Sound *) 0 ;
+  double arg2 = (double) 1.0 ;
+  double arg3 = (double) 1.0 ;
   bool arg4 = (bool) false ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -8234,11 +8234,11 @@ _wrap_Sample_play(int argc, VALUE *argv, VALUE self) {
   if ((argc < 0) || (argc > 3)) {
     rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
   }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_Gosu__Sample, 0 |  0 );
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_Gosu__Sound, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "Gosu::Sample const *","play", 1, self )); 
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "Gosu::Sound const *","play", 1, self )); 
   }
-  arg1 = reinterpret_cast< Gosu::Sample * >(argp1);
+  arg1 = reinterpret_cast< Gosu::Sound * >(argp1);
   if (argc > 0) {
     ecode2 = SWIG_AsVal_double(argv[0], &val2);
     if (!SWIG_IsOK(ecode2)) {
@@ -8262,7 +8262,7 @@ _wrap_Sample_play(int argc, VALUE *argv, VALUE self) {
   }
   {
     try {
-      result = ((Gosu::Sample const *)arg1)->play(arg2,arg3,arg4);
+      result = ((Gosu::Sound const *)arg1)->play(arg2,arg3,arg4);
     }
     catch (const std::exception& e) {
       SWIG_exception(SWIG_RuntimeError, e.what());
@@ -8276,11 +8276,11 @@ fail:
 
 
 SWIGINTERN VALUE
-_wrap_Sample_play_pan(int argc, VALUE *argv, VALUE self) {
-  Gosu::Sample *arg1 = (Gosu::Sample *) 0 ;
+_wrap_Sound_play_pan(int argc, VALUE *argv, VALUE self) {
+  Gosu::Sound *arg1 = (Gosu::Sound *) 0 ;
   double arg2 ;
-  double arg3 = (double) 1 ;
-  double arg4 = (double) 1 ;
+  double arg3 = (double) 1.0 ;
+  double arg4 = (double) 1.0 ;
   bool arg5 = (bool) false ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -8298,11 +8298,11 @@ _wrap_Sample_play_pan(int argc, VALUE *argv, VALUE self) {
   if ((argc < 1) || (argc > 4)) {
     rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
   }
-  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_Gosu__Sample, 0 |  0 );
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_Gosu__Sound, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "Gosu::Sample const *","play_pan", 1, self )); 
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "Gosu::Sound const *","play_pan", 1, self )); 
   }
-  arg1 = reinterpret_cast< Gosu::Sample * >(argp1);
+  arg1 = reinterpret_cast< Gosu::Sound * >(argp1);
   ecode2 = SWIG_AsVal_double(argv[0], &val2);
   if (!SWIG_IsOK(ecode2)) {
     SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "double","play_pan", 2, argv[0] ));
@@ -8331,7 +8331,7 @@ _wrap_Sample_play_pan(int argc, VALUE *argv, VALUE self) {
   }
   {
     try {
-      result = ((Gosu::Sample const *)arg1)->play_pan(arg2,arg3,arg4,arg5);
+      result = ((Gosu::Sound const *)arg1)->play_pan(arg2,arg3,arg4,arg5);
     }
     catch (const std::exception& e) {
       SWIG_exception(SWIG_RuntimeError, e.what());
@@ -8345,8 +8345,8 @@ fail:
 
 
 SWIGINTERN void
-free_Gosu_Sample(void *self) {
-    Gosu::Sample *arg1 = (Gosu::Sample *)self;
+free_Gosu_Sound(void *self) {
+    Gosu::Sound *arg1 = (Gosu::Sound *)self;
     SWIG_RubyRemoveTracking(arg1);
     delete arg1;
 }
@@ -12175,8 +12175,8 @@ static swig_type_info _swigt__p_Gosu__Color = {"_p_Gosu__Color", "Gosu::Color *"
 static swig_type_info _swigt__p_Gosu__Font = {"_p_Gosu__Font", "Gosu::Font *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_Gosu__GLTexInfo = {"_p_Gosu__GLTexInfo", "Gosu::GLTexInfo *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_Gosu__Image = {"_p_Gosu__Image", "Gosu::Image *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_Gosu__Sample = {"_p_Gosu__Sample", "Gosu::Sample *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_Gosu__Song = {"_p_Gosu__Song", "Gosu::Song *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_Gosu__Sound = {"_p_Gosu__Sound", "Gosu::Sound *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_Gosu__TextInput = {"_p_Gosu__TextInput", "Gosu::TextInput *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_Gosu__Window = {"_p_Gosu__Window", "Gosu::Window *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
@@ -12190,8 +12190,8 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_Gosu__Font,
   &_swigt__p_Gosu__GLTexInfo,
   &_swigt__p_Gosu__Image,
-  &_swigt__p_Gosu__Sample,
   &_swigt__p_Gosu__Song,
+  &_swigt__p_Gosu__Sound,
   &_swigt__p_Gosu__TextInput,
   &_swigt__p_Gosu__Window,
   &_swigt__p_char,
@@ -12205,8 +12205,8 @@ static swig_cast_info _swigc__p_Gosu__Color[] = {  {&_swigt__p_Gosu__Color, 0, 0
 static swig_cast_info _swigc__p_Gosu__Font[] = {  {&_swigt__p_Gosu__Font, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_Gosu__GLTexInfo[] = {  {&_swigt__p_Gosu__GLTexInfo, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_Gosu__Image[] = {  {&_swigt__p_Gosu__Image, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_Gosu__Sample[] = {  {&_swigt__p_Gosu__Sample, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_Gosu__Song[] = {  {&_swigt__p_Gosu__Song, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_Gosu__Sound[] = {  {&_swigt__p_Gosu__Sound, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_Gosu__TextInput[] = {  {&_swigt__p_Gosu__TextInput, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_Gosu__Window[] = {  {&_swigt__p_Gosu__Window, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
@@ -12220,8 +12220,8 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_Gosu__Font,
   _swigc__p_Gosu__GLTexInfo,
   _swigc__p_Gosu__Image,
-  _swigc__p_Gosu__Sample,
   _swigc__p_Gosu__Song,
+  _swigc__p_Gosu__Sound,
   _swigc__p_Gosu__TextInput,
   _swigc__p_Gosu__Window,
   _swigc__p_char,
@@ -12616,15 +12616,15 @@ SWIGEXPORT void Init_gosu(void) {
   SwigClassChannel.destroy = (void (*)(void *)) free_Gosu_Channel;
   SwigClassChannel.trackObjects = 1;
   
-  SwigClassSample.klass = rb_define_class_under(mGosu, "Sample", rb_cObject);
-  SWIG_TypeClientData(SWIGTYPE_p_Gosu__Sample, (void *) &SwigClassSample);
-  rb_define_alloc_func(SwigClassSample.klass, _wrap_Sample_allocate);
-  rb_define_method(SwigClassSample.klass, "initialize", VALUEFUNC(_wrap_new_Sample), -1);
-  rb_define_method(SwigClassSample.klass, "play", VALUEFUNC(_wrap_Sample_play), -1);
-  rb_define_method(SwigClassSample.klass, "play_pan", VALUEFUNC(_wrap_Sample_play_pan), -1);
-  SwigClassSample.mark = 0;
-  SwigClassSample.destroy = (void (*)(void *)) free_Gosu_Sample;
-  SwigClassSample.trackObjects = 1;
+  SwigClassSound.klass = rb_define_class_under(mGosu, "Sound", rb_cObject);
+  SWIG_TypeClientData(SWIGTYPE_p_Gosu__Sound, (void *) &SwigClassSound);
+  rb_define_alloc_func(SwigClassSound.klass, _wrap_Sound_allocate);
+  rb_define_method(SwigClassSound.klass, "initialize", VALUEFUNC(_wrap_new_Sound), -1);
+  rb_define_method(SwigClassSound.klass, "play", VALUEFUNC(_wrap_Sound_play), -1);
+  rb_define_method(SwigClassSound.klass, "play_pan", VALUEFUNC(_wrap_Sound_play_pan), -1);
+  SwigClassSound.mark = 0;
+  SwigClassSound.destroy = (void (*)(void *)) free_Gosu_Sound;
+  SwigClassSound.trackObjects = 1;
   
   SwigClassSong.klass = rb_define_class_under(mGosu, "Song", rb_cObject);
   SWIG_TypeClientData(SWIGTYPE_p_Gosu__Song, (void *) &SwigClassSong);

--- a/test/test_audio.rb
+++ b/test/test_audio.rb
@@ -11,7 +11,7 @@ class TestAudio < Minitest::Test
     skip_on_appveyor
     skip_on_github
 
-    sound = Gosu::Sample.new(media_path("0614.ogg"))
+    sound = Gosu::Sound.new(media_path("0614.ogg"))
     channel = sound.play(1, 1, true)
     interactive_cli("Do you hear a Star Wars-like Blaster sound?")
     

--- a/test/test_deprecations.rb
+++ b/test/test_deprecations.rb
@@ -14,8 +14,8 @@ class TestDeprecations < Minitest::Test
   end
 
   def test_window_no_longer_needed
-    assert_output("", /DEPRECATION WARNING: Passing a Window to Sample#initialize has been deprecated in Gosu 0.7.17./) do
-      assert_raises(::ArgumentError) { Gosu::Sample.new(DUMMY_WINDOW) }
+    assert_output("", /DEPRECATION WARNING: Passing a Window to Sound#initialize has been deprecated in Gosu 0.7.17./) do
+      assert_raises(::ArgumentError) { Gosu::Sound.new(DUMMY_WINDOW) }
     end
 
     assert_output("", /DEPRECATION WARNING: Passing a Window to Song#initialize has been deprecated in Gosu 0.7.17./) do

--- a/windows/GosuFFI.vcxproj
+++ b/windows/GosuFFI.vcxproj
@@ -26,7 +26,7 @@
     <ClInclude Include="..\ffi\Gosu_FFI_internal.h" />
     <ClInclude Include="..\ffi\Gosu_Font.h" />
     <ClInclude Include="..\ffi\Gosu_Image.h" />
-    <ClInclude Include="..\ffi\Gosu_Sample.h" />
+    <ClInclude Include="..\ffi\Gosu_Sound.h" />
     <ClInclude Include="..\ffi\Gosu_Song.h" />
     <ClInclude Include="..\ffi\Gosu_TextInput.h" />
     <ClInclude Include="..\ffi\Gosu_Window.h" />
@@ -38,7 +38,7 @@
     <ClCompile Include="..\ffi\Gosu_Constants.cpp" />
     <ClCompile Include="..\ffi\Gosu_Font.cpp" />
     <ClCompile Include="..\ffi\Gosu_Image.cpp" />
-    <ClCompile Include="..\ffi\Gosu_Sample.cpp" />
+    <ClCompile Include="..\ffi\Gosu_Sound.cpp" />
     <ClCompile Include="..\ffi\Gosu_Song.cpp" />
     <ClCompile Include="..\ffi\Gosu_TextInput.cpp" />
     <ClCompile Include="..\ffi\Gosu_Window.cpp" />

--- a/windows/GosuFFI.vcxproj.filters
+++ b/windows/GosuFFI.vcxproj.filters
@@ -32,7 +32,7 @@
     <ClInclude Include="..\ffi\Gosu_Image.h">
       <Filter>Interface</Filter>
     </ClInclude>
-    <ClInclude Include="..\ffi\Gosu_Sample.h">
+    <ClInclude Include="..\ffi\Gosu_Sound.h">
       <Filter>Interface</Filter>
     </ClInclude>
     <ClInclude Include="..\ffi\Gosu_Song.h">
@@ -64,7 +64,7 @@
     <ClCompile Include="..\ffi\Gosu_Image.cpp">
       <Filter>Implementation</Filter>
     </ClCompile>
-    <ClCompile Include="..\ffi\Gosu_Sample.cpp">
+    <ClCompile Include="..\ffi\Gosu_Sound.cpp">
       <Filter>Implementation</Filter>
     </ClCompile>
     <ClCompile Include="..\ffi\Gosu_Song.cpp">


### PR DESCRIPTION
One "issue" with using SDL_sound for audio loading is that it supports formats with built-in loop points. When Gosu::Sample#initialize tries to completely preload such a file, it will crash.

This seems like a great chance to merge Sample & Song by having them both stream the file by default. If it is short enough, it can stay loaded in memory as an optimization (= the old Sample behavior).

This was meant to land in Gosu 1.0, but given #560, I think I will push this back since it is easy enough to work around this issue during development by not using looping samples.