### PR TITLE
Window tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [1.1.0] - tbd
 
-* Windows: Pin the main thread to a single processor core during Window::show to avoid timing glitches.
+* `Gosu::Window` can now be created with `borderless: true` (`WF_BORDERLESS` in C++) to hide all window chrome. Thanks to @cyberarm for this contribution.
+* `Gosu::Window#resizable=` and `Gosu::Window#borderless=` allow changing these properties later.
+* Windows: Pin the main thread to the first processor core during `Window::show` to avoid timing glitches.
 
 ## [1.0.0] – 2020-12-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.0] - tbd
+
+* Windows: Pin the main thread to a single processor core during Window::show to avoid timing glitches.
+
 ## [1.0.0] – 2020-12-29
 
 * Breaking change: `Image.from_text`, `Font.draw_text` and `Font.text_width` have stopped parsing pseudo-HTML markup. Replace "text" with "markup" in each method name to get this functionality back.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # - This is not (yet?) going to replace the Visual Studio project for Windows.
 cmake_minimum_required(VERSION 3.10...3.18.4)
 
-project(Gosu VERSION 1.0.0)
+project(Gosu VERSION 1.1.0)
 
 
 ##############################################

--- a/Gosu.podspec
+++ b/Gosu.podspec
@@ -12,14 +12,16 @@ Pod::Spec.new do |s|
   # Bundle our dependencies into one subspec so that we can silence warnings for them.
   s.subspec "Dependencies" do |ss|
     ss.compiler_flags = "-Wno-everything"
-    ss.source_files = "dependencies/{stb,utf8proc,SDL_sound}/**/*.{h,c}"
+    # Be careful not to include SDL_sound on iOS, where Gosu still uses AudioToolbox instead.
+    ss.source_files = "dependencies/{stb,utf8proc}/**/*.{h,c}"
+    ss.osx.source_files = "dependencies/SDL_sound/**/*.{h,c}"
     ss.osx.compiler_flags = "-I/usr/local/include/SDL2"
   end
 
   s.subspec "Gosu" do |ss|
     ss.dependency "Gosu/Dependencies"
     ss.osx.deployment_target = "10.9"
-    ss.ios.deployment_target = "8.0"
+    ss.ios.deployment_target = "11.4"
     
     # Ignore Gosu using deprecated Gosu APIs internally.
     # Compile all source files as Objective-C++ so we can use ObjC frameworks where necessary.
@@ -30,7 +32,7 @@ Pod::Spec.new do |s|
     ss.frameworks = "AudioToolbox", "OpenAL"
     # Include all frameworks necessary for SDL 2, because we link to it statically.
     ss.osx.frameworks = "ApplicationServices", "AudioUnit", "Carbon", "Cocoa", "CoreAudio",
-                        "ForceFeedback", "IOKit", "OpenGL", "Metal"
+                        "ForceFeedback", "IOKit", "OpenGL", "Metal", "GameController"
     # Frameworks used directly by Gosu for iOS.
     ss.ios.frameworks = "AVFoundation", "CoreGraphics", "OpenGLES", "QuartzCore"
     

--- a/Gosu.podspec
+++ b/Gosu.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = "Gosu"
-  s.version  = "1.0.0"
+  s.version  = "1.1.0"
   s.summary  = "2D game development library."
   s.homepage = "https://www.libgosu.org/"
   s.license  = { type: "MIT", file: "COPYING" }

--- a/examples/Tutorial-Touch/Podfile
+++ b/examples/Tutorial-Touch/Podfile
@@ -1,4 +1,4 @@
-platform :ios, "8.0"
+platform :ios, "11.4"
 
 target "Tutorial-Touch" do
   # GosuAppDelegateMain is a subspec of the Gosu pod that contains a "main()" function.

--- a/examples/Tutorial-Touch/Podfile.lock
+++ b/examples/Tutorial-Touch/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - Gosu/C (0.15.2)
-  - Gosu/Gosu (0.15.2):
-    - Gosu/C
-  - Gosu/GosuAppDelegateMain (0.15.2):
+  - Gosu/Dependencies (1.1.0)
+  - Gosu/Gosu (1.1.0):
+    - Gosu/Dependencies
+  - Gosu/GosuAppDelegateMain (1.1.0):
     - Gosu/Gosu
 
 DEPENDENCIES:
@@ -13,8 +13,8 @@ EXTERNAL SOURCES:
     :path: "../.."
 
 SPEC CHECKSUMS:
-  Gosu: 8905cc6cab83b7cd66660cf70d7d4c00ccb35b4b
+  Gosu: 6c57416ec28a8fc8266355651b4d281d2a2b90f3
 
-PODFILE CHECKSUM: ee2d9c27c9bc13d2dd770377872df3856e4f0efa
+PODFILE CHECKSUM: f8cd52c8c957102d1f0a73c25f732e809fb83a18
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.0

--- a/examples/Tutorial-Touch/Tutorial-Touch.xcodeproj/project.pbxproj
+++ b/examples/Tutorial-Touch/Tutorial-Touch.xcodeproj/project.pbxproj
@@ -312,7 +312,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				INFOPLIST_FILE = "Tutorial-Touch/Tutorial-Touch-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.libgosu.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
@@ -327,7 +327,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				INFOPLIST_FILE = "Tutorial-Touch/Tutorial-Touch-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.libgosu.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;

--- a/examples/Tutorial/Podfile.lock
+++ b/examples/Tutorial/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - Gosu (0.15.2):
-    - Gosu/Gosu (= 0.15.2)
-  - Gosu/Dependencies (0.15.2)
-  - Gosu/Gosu (0.15.2):
+  - Gosu (1.1.0):
+    - Gosu/Gosu (= 1.1.0)
+  - Gosu/Dependencies (1.1.0)
+  - Gosu/Gosu (1.1.0):
     - Gosu/Dependencies
 
 DEPENDENCIES:
@@ -13,7 +13,7 @@ EXTERNAL SOURCES:
     :path: "../.."
 
 SPEC CHECKSUMS:
-  Gosu: e819d2fefeb37859bbfdf611f9332cc9b79ca695
+  Gosu: 6c57416ec28a8fc8266355651b4d281d2a2b90f3
 
 PODFILE CHECKSUM: 6d90e9429378d42966ff3eff051b194170f3f19b
 

--- a/ext/gosu/gosu.i
+++ b/ext/gosu/gosu.i
@@ -1065,10 +1065,13 @@ namespace Gosu
 };
 
 // Window
-%ignore Gosu::Window::resize(unsigned, unsigned, bool);
+%ignore Gosu::WindowFlags;
+%ignore Gosu::Window::resize;
 %rename("width=") set_width;
 %rename("height=") set_height;
 %rename("fullscreen=") set_fullscreen;
+%rename("resizable=") set_resizable;
+%rename("borderless=") set_borderless;
 %rename("update_interval=") set_update_interval;
 %rename("caption=") set_caption;
 %rename("text_input=") set_text_input;
@@ -1079,6 +1082,7 @@ namespace Gosu
 %rename("close!") force_close;
 %rename("fullscreen?") fullscreen;
 %rename("resizable?") resizable;
+%rename("borderless?") borderless;
 %markfunc Gosu::Window "mark_window";
 %include "../../include/Gosu/Window.hpp"
 

--- a/ffi/Gosu.cpp
+++ b/ffi/Gosu.cpp
@@ -120,22 +120,22 @@ GOSU_FFI_API double Gosu_random(double min, double max)
     return Gosu::random(min, max);
 }
 
-GOSU_FFI_API unsigned Gosu_available_width(Gosu_Window* window)
+GOSU_FFI_API int Gosu_available_width(Gosu_Window* window)
 {
     return Gosu::available_width(window);
 }
 
-GOSU_FFI_API unsigned Gosu_available_height(Gosu_Window* window)
+GOSU_FFI_API int Gosu_available_height(Gosu_Window* window)
 {
     return Gosu::available_height(window);
 }
 
-GOSU_FFI_API unsigned Gosu_screen_width(Gosu_Window* window)
+GOSU_FFI_API int Gosu_screen_width(Gosu_Window* window)
 {
     return Gosu::screen_width(window);
 }
 
-GOSU_FFI_API unsigned Gosu_screen_height(Gosu_Window* window)
+GOSU_FFI_API int Gosu_screen_height(Gosu_Window* window)
 {
     return Gosu::screen_height(window);
 }

--- a/ffi/Gosu.h
+++ b/ffi/Gosu.h
@@ -56,10 +56,10 @@ GOSU_FFI_API double Gosu_offset_y(double angle, double radius);
 GOSU_FFI_API double Gosu_random(double min, double max);
 
 // Window/Screen information
-GOSU_FFI_API unsigned Gosu_available_width(Gosu_Window* window);
-GOSU_FFI_API unsigned Gosu_available_height(Gosu_Window* window);
-GOSU_FFI_API unsigned Gosu_screen_width(Gosu_Window* window);
-GOSU_FFI_API unsigned Gosu_screen_height(Gosu_Window* window);
+GOSU_FFI_API int Gosu_available_width(Gosu_Window* window);
+GOSU_FFI_API int Gosu_available_height(Gosu_Window* window);
+GOSU_FFI_API int Gosu_screen_width(Gosu_Window* window);
+GOSU_FFI_API int Gosu_screen_height(Gosu_Window* window);
 
 // Button querying
 GOSU_FFI_API int Gosu_button_down(int id);

--- a/ffi/Gosu_Constants.cpp
+++ b/ffi/Gosu_Constants.cpp
@@ -14,6 +14,12 @@ GOSU_FFI_API const unsigned Gosu_MAJOR_VERSION = GOSU_MAJOR_VERSION;
 GOSU_FFI_API const unsigned Gosu_MINOR_VERSION = GOSU_MINOR_VERSION;
 GOSU_FFI_API const unsigned Gosu_POINT_VERSION = GOSU_POINT_VERSION;
 
+// Window Flags
+GOSU_FFI_API const unsigned Gosu_WF_WINDOWED = Gosu::WF_WINDOWED;
+GOSU_FFI_API const unsigned Gosu_WF_FULLSCREEN = Gosu::WF_FULLSCREEN;
+GOSU_FFI_API const unsigned Gosu_WF_RESIZABLE = Gosu::WF_RESIZABLE;
+GOSU_FFI_API const unsigned Gosu_WF_BORDERLESS = Gosu::WF_BORDERLESS;
+
 // Alpha/Blend Modes
 GOSU_FFI_API const unsigned Gosu_AM_DEFAULT = Gosu::AM_DEFAULT;
 GOSU_FFI_API const unsigned Gosu_AM_INTERPOLATE = Gosu::AM_INTERPOLATE;

--- a/ffi/Gosu_FFI_internal.h
+++ b/ffi/Gosu_FFI_internal.h
@@ -55,8 +55,8 @@ struct Gosu_TextInput : public Gosu::TextInput
 struct Gosu_Window : public Gosu::Window
 {
     [[maybe_unused]] // silence buggy warning, this is being used in Gosu_Window.cpp.
-    Gosu_Window(int width, int height, bool fullscreen, double update_interval, bool resizable)
-    : Gosu::Window(width, height, fullscreen, update_interval, resizable)
+    Gosu_Window(int width, int height, unsigned window_flags, double update_interval)
+    : Gosu::Window(width, height, window_flags, update_interval)
     {
     }
 
@@ -115,10 +115,10 @@ struct Gosu_Window : public Gosu::Window
 
     std::function<void()> update_callback;
     std::function<void()> draw_callback;
-    std::function<void(unsigned btn)> button_down_callback;
-    std::function<void(unsigned btn)> button_up_callback;
-    std::function<void(int id)> gamepad_connected_callback;
-    std::function<void(int id)> gamepad_disconnected_callback;
+    std::function<void(unsigned id)> button_down_callback;
+    std::function<void(unsigned id)> button_up_callback;
+    std::function<void(int index)> gamepad_connected_callback;
+    std::function<void(int index)> gamepad_disconnected_callback;
     std::function<void(const char* filename)> drop_callback;
     std::function<bool()> needs_redraw_callback;
     std::function<bool()> needs_cursor_callback;

--- a/ffi/Gosu_Image.cpp
+++ b/ffi/Gosu_Image.cpp
@@ -40,8 +40,8 @@ GOSU_FFI_API Gosu_Image* Gosu_Image_create_from_blob(void* blob, int byte_count,
         // 128 bit per channel, assume float/float/float/float - for Texplay compatibility.
         const float* in = static_cast<const float*>(blob);
         Gosu::Color::Channel* out = reinterpret_cast<Gosu::Color::Channel*>(bitmap.data());
-        for (int i = size; i > 0; --i) {
-            *out++ = static_cast<Gosu::Color::Channel>(*in++ * 255);
+        for (std::size_t i = 0; i < size; ++i) {
+            out[i] = static_cast<Gosu::Color::Channel>(in[i] * 255);
         }
     }
     else {

--- a/ffi/Gosu_Window.cpp
+++ b/ffi/Gosu_Window.cpp
@@ -1,9 +1,11 @@
 #include "Gosu_FFI_internal.h"
 
-GOSU_FFI_API Gosu_Window* Gosu_Window_create(int width, int height, bool fullscreen,
-                                             double update_interval, bool resizable)
+// Lifecycle
+
+GOSU_FFI_API Gosu_Window* Gosu_Window_create(int width, int height, unsigned window_flags,
+                                             double update_interval)
 {
-    return new Gosu_Window(width, height, fullscreen, update_interval, resizable);
+    return new Gosu_Window{width, height, window_flags, update_interval};
 };
 
 GOSU_FFI_API void Gosu_Window_destroy(Gosu_Window* window)
@@ -11,25 +13,22 @@ GOSU_FFI_API void Gosu_Window_destroy(Gosu_Window* window)
     delete window;
 }
 
-GOSU_FFI_API void Gosu_Window_set_draw(Gosu_Window* window, void function(void*), void* data)
-{
-    window->draw_callback = [=] { function(data); };
-}
+// Callbacks
 
 GOSU_FFI_API void Gosu_Window_set_update(Gosu_Window* window, void function(void*), void* data)
 {
     window->update_callback = [=] { function(data); };
 }
 
+GOSU_FFI_API void Gosu_Window_set_draw(Gosu_Window* window, void function(void*), void* data)
+{
+    window->draw_callback = [=] { function(data); };
+}
+
 GOSU_FFI_API void Gosu_Window_set_button_down(Gosu_Window* window, void function(void*, unsigned),
                                               void* data)
 {
     window->button_down_callback = [=](unsigned btn) { function(data, btn); };
-}
-
-GOSU_FFI_API void Gosu_Window_default_button_down(Gosu_Window* window, unsigned btn)
-{
-    window->Gosu::Window::button_down(static_cast<Gosu::Button>(btn));
 }
 
 GOSU_FFI_API void Gosu_Window_set_button_up(Gosu_Window* window, void function(void*, unsigned),
@@ -73,82 +72,12 @@ GOSU_FFI_API void Gosu_Window_set_close(Gosu_Window* window, void function(void*
     window->close_callback = [=] { function(data); };
 }
 
-GOSU_FFI_API Gosu_TextInput* Gosu_Window_text_input(Gosu_Window* window)
+GOSU_FFI_API void Gosu_Window_default_button_down(Gosu_Window* window, unsigned id)
 {
-    return dynamic_cast<Gosu_TextInput*>(window->input().text_input());
+    window->Gosu::Window::button_down(static_cast<Gosu::Button>(id));
 }
 
-GOSU_FFI_API void Gosu_Window_set_text_input(Gosu_Window* window, Gosu_TextInput* text_input)
-{
-    window->input().set_text_input(text_input);
-}
-
-GOSU_FFI_API void Gosu_Window_show(Gosu_Window* window)
-{
-    window->show();
-}
-
-GOSU_FFI_API bool Gosu_Window_tick(Gosu_Window* window)
-{
-    return window->tick();
-}
-
-GOSU_FFI_API void Gosu_Window_close_immediately(Gosu_Window* window)
-{
-    window->Gosu::Window::close();
-}
-
-GOSU_FFI_API bool Gosu_Window_is_fullscreen(Gosu_Window* window)
-{
-    return window->fullscreen();
-}
-
-GOSU_FFI_API bool Gosu_Window_is_resizable(Gosu_Window* window)
-{
-    return window->resizable();
-}
-
-GOSU_FFI_API const char* Gosu_Window_caption(Gosu_Window* window)
-{
-    static thread_local std::string caption;
-    caption = window->caption();
-    return caption.c_str();
-}
-
-GOSU_FFI_API void Gosu_Window_set_caption(Gosu_Window* window, const char* caption)
-{
-    window->set_caption(caption);
-}
-
-GOSU_FFI_API double Gosu_Window_update_interval(Gosu_Window* window)
-{
-    return window->update_interval();
-}
-
-GOSU_FFI_API void Gosu_Window_set_update_interval(Gosu_Window* window, double update_interval)
-{
-    window->set_update_interval(update_interval);
-}
-
-GOSU_FFI_API void Gosu_Window_set_mouse_x(Gosu_Window* window, double x)
-{
-    window->input().set_mouse_position(x, window->input().mouse_x());
-}
-
-GOSU_FFI_API void Gosu_Window_set_mouse_y(Gosu_Window* window, double y)
-{
-    window->input().set_mouse_position(window->input().mouse_x(), y);
-}
-
-GOSU_FFI_API double Gosu_Window_mouse_x(Gosu_Window* window)
-{
-    return window->input().mouse_x();
-}
-
-GOSU_FFI_API double Gosu_Window_mouse_y(Gosu_Window* window)
-{
-    return window->input().mouse_y();
-}
+// Properties
 
 GOSU_FFI_API int Gosu_Window_width(Gosu_Window* window)
 {
@@ -170,7 +99,108 @@ GOSU_FFI_API void Gosu_Window_set_height(Gosu_Window* window, int height)
     window->resize(window->width(), height, window->fullscreen());
 }
 
+GOSU_FFI_API bool Gosu_Window_is_fullscreen(Gosu_Window* window)
+{
+    return window->fullscreen();
+}
+
+GOSU_FFI_API void Gosu_Window_set_fullscreen(Gosu_Window* window, bool fullscreen)
+{
+    window->resize(window->width(), window->height(), fullscreen);
+}
+
 GOSU_FFI_API void Gosu_Window_resize(Gosu_Window* window, int width, int height, bool fullscreen)
 {
     window->resize(width, height, fullscreen);
+}
+
+GOSU_FFI_API bool Gosu_Window_is_resizable(Gosu_Window* window)
+{
+    return window->resizable();
+}
+
+GOSU_FFI_API void Gosu_Window_set_resizable(Gosu_Window* window, bool resizable)
+{
+    window->set_resizable(resizable);
+}
+
+GOSU_FFI_API bool Gosu_Window_is_borderless(Gosu_Window* window)
+{
+    return window->borderless();
+}
+
+GOSU_FFI_API void Gosu_Window_set_borderless(Gosu_Window* window, bool borderless)
+{
+    window->set_borderless(borderless);
+}
+
+GOSU_FFI_API double Gosu_Window_update_interval(Gosu_Window* window)
+{
+    return window->update_interval();
+}
+
+GOSU_FFI_API void Gosu_Window_set_update_interval(Gosu_Window* window, double update_interval)
+{
+    window->set_update_interval(update_interval);
+}
+
+GOSU_FFI_API const char* Gosu_Window_caption(Gosu_Window* window)
+{
+    static thread_local std::string caption;
+    caption = window->caption();
+    return caption.c_str();
+}
+
+GOSU_FFI_API void Gosu_Window_set_caption(Gosu_Window* window, const char* caption)
+{
+    window->set_caption(caption);
+}
+
+// Input Properties
+
+GOSU_FFI_API Gosu_TextInput* Gosu_Window_text_input(Gosu_Window* window)
+{
+    return dynamic_cast<Gosu_TextInput*>(window->input().text_input());
+}
+
+GOSU_FFI_API void Gosu_Window_set_text_input(Gosu_Window* window, Gosu_TextInput* text_input)
+{
+    window->input().set_text_input(text_input);
+}
+
+GOSU_FFI_API double Gosu_Window_mouse_x(Gosu_Window* window)
+{
+    return window->input().mouse_x();
+}
+
+GOSU_FFI_API void Gosu_Window_set_mouse_x(Gosu_Window* window, double x)
+{
+    window->input().set_mouse_position(x, window->input().mouse_x());
+}
+
+GOSU_FFI_API double Gosu_Window_mouse_y(Gosu_Window* window)
+{
+    return window->input().mouse_y();
+}
+
+GOSU_FFI_API void Gosu_Window_set_mouse_y(Gosu_Window* window, double y)
+{
+    window->input().set_mouse_position(window->input().mouse_x(), y);
+}
+
+// Main Loop
+
+GOSU_FFI_API void Gosu_Window_show(Gosu_Window* window)
+{
+    window->show();
+}
+
+GOSU_FFI_API bool Gosu_Window_tick(Gosu_Window* window)
+{
+    return window->tick();
+}
+
+GOSU_FFI_API void Gosu_Window_close_immediately(Gosu_Window* window)
+{
+    window->Gosu::Window::close();
 }

--- a/ffi/Gosu_Window.h
+++ b/ffi/Gosu_Window.h
@@ -6,25 +6,26 @@
 
 typedef struct Gosu_Window Gosu_Window;
 
-// Constructor
-GOSU_FFI_API Gosu_Window* Gosu_Window_create(int width, int height, bool fullscreen,
-                                             double update_interval, bool resizable);
+// Lifecycle
 
-// Destructor
+GOSU_FFI_API Gosu_Window* Gosu_Window_create(int width, int height, unsigned window_flags,
+                                             double update_interval);
 GOSU_FFI_API void Gosu_Window_destroy(Gosu_Window* window);
 
-// callbacks
+// Callbacks
+
 GOSU_FFI_API void Gosu_Window_set_update(Gosu_Window* window, void function(void* data),
                                          void* data);
 GOSU_FFI_API void Gosu_Window_set_draw(Gosu_Window* window, void function(void* data), void* data);
 GOSU_FFI_API void Gosu_Window_set_button_down(Gosu_Window* window,
-                                              void function(void* data, unsigned btn), void* data);
+                                              void function(void* data, unsigned id), void* data);
 GOSU_FFI_API void Gosu_Window_set_button_up(Gosu_Window* window,
-                                            void function(void* data, unsigned btn), void* data);
+                                            void function(void* data, unsigned id), void* data);
 GOSU_FFI_API void Gosu_Window_set_gamepad_connected(Gosu_Window* window,
-                                                    void function(void* data, int id), void* data);
+                                                    void function(void* data, int index),
+                                                    void* data);
 GOSU_FFI_API void Gosu_Window_set_gamepad_disconnected(Gosu_Window* window,
-                                                       void function(void* data, int id),
+                                                       void function(void* data, int index),
                                                        void* data);
 GOSU_FFI_API void Gosu_Window_set_drop(Gosu_Window* window,
                                        void function(void* data, const char* filename), void* data);
@@ -34,32 +35,40 @@ GOSU_FFI_API void Gosu_Window_set_needs_cursor(Gosu_Window* window, bool functio
                                                void* data);
 GOSU_FFI_API void Gosu_Window_set_close(Gosu_Window* window, void function(void* data), void* data);
 
-GOSU_FFI_API void Gosu_Window_default_button_down(Gosu_Window* window, unsigned btn);
+GOSU_FFI_API void Gosu_Window_default_button_down(Gosu_Window* window, unsigned id);
 
 // Properties
+
 GOSU_FFI_API int Gosu_Window_width(Gosu_Window* window);
-GOSU_FFI_API int Gosu_Window_height(Gosu_Window* window);
-GOSU_FFI_API bool Gosu_Window_is_fullscreen(Gosu_Window* window);
-GOSU_FFI_API bool Gosu_Window_is_resizable(Gosu_Window* window);
-GOSU_FFI_API double Gosu_Window_update_interval(Gosu_Window* window);
-GOSU_FFI_API const char* Gosu_Window_caption(Gosu_Window* window);
-
-GOSU_FFI_API Gosu_TextInput* Gosu_Window_text_input(Gosu_Window* window);
-GOSU_FFI_API double Gosu_Window_mouse_x(Gosu_Window* window);
-GOSU_FFI_API double Gosu_Window_mouse_y(Gosu_Window* window);
-
-// Setters
-GOSU_FFI_API void Gosu_Window_set_text_input(Gosu_Window* window, Gosu_TextInput* text_input);
-GOSU_FFI_API void Gosu_Window_set_caption(Gosu_Window* window, const char* caption);
-GOSU_FFI_API void Gosu_Window_set_update_interval(Gosu_Window* window, double update_interval);
-GOSU_FFI_API void Gosu_Window_set_mouse_x(Gosu_Window* window, double width);
-GOSU_FFI_API void Gosu_Window_set_mouse_y(Gosu_Window* window, double height);
 GOSU_FFI_API void Gosu_Window_set_width(Gosu_Window* window, int width);
+GOSU_FFI_API int Gosu_Window_height(Gosu_Window* window);
 GOSU_FFI_API void Gosu_Window_set_height(Gosu_Window* window, int height);
-
+GOSU_FFI_API bool Gosu_Window_is_fullscreen(Gosu_Window* window);
+GOSU_FFI_API void Gosu_Window_set_fullscreen(Gosu_Window* window, bool fullscreen);
 GOSU_FFI_API void Gosu_Window_resize(Gosu_Window* window, int width, int height, bool fullscreen);
 
+GOSU_FFI_API bool Gosu_Window_is_resizable(Gosu_Window* window);
+GOSU_FFI_API void Gosu_Window_set_resizable(Gosu_Window* window, bool resizable);
+GOSU_FFI_API bool Gosu_Window_is_borderless(Gosu_Window* window);
+GOSU_FFI_API void Gosu_Window_set_borderless(Gosu_Window* window, bool borderless);
+
+GOSU_FFI_API double Gosu_Window_update_interval(Gosu_Window* window);
+GOSU_FFI_API void Gosu_Window_set_update_interval(Gosu_Window* window, double update_interval);
+
+GOSU_FFI_API const char* Gosu_Window_caption(Gosu_Window* window);
+GOSU_FFI_API void Gosu_Window_set_caption(Gosu_Window* window, const char* caption);
+
+// Input Properties
+
+GOSU_FFI_API Gosu_TextInput* Gosu_Window_text_input(Gosu_Window* window);
+GOSU_FFI_API void Gosu_Window_set_text_input(Gosu_Window* window, Gosu_TextInput* text_input);
+GOSU_FFI_API double Gosu_Window_mouse_x(Gosu_Window* window);
+GOSU_FFI_API void Gosu_Window_set_mouse_x(Gosu_Window* window, double width);
+GOSU_FFI_API double Gosu_Window_mouse_y(Gosu_Window* window);
+GOSU_FFI_API void Gosu_Window_set_mouse_y(Gosu_Window* window, double height);
+
 // Main Loop
+
 GOSU_FFI_API void Gosu_Window_show(Gosu_Window* window);
-GOSU_FFI_API void Gosu_Window_close_immediately(Gosu_Window* window);
 GOSU_FFI_API bool Gosu_Window_tick(Gosu_Window* window);
+GOSU_FFI_API void Gosu_Window_close_immediately(Gosu_Window* window);

--- a/include/Gosu/Version.hpp
+++ b/include/Gosu/Version.hpp
@@ -3,7 +3,7 @@
 #include <string>
 
 #define GOSU_MAJOR_VERSION 1
-#define GOSU_MINOR_VERSION 0
+#define GOSU_MINOR_VERSION 1
 #define GOSU_POINT_VERSION 0
 
 namespace Gosu

--- a/include/Gosu/Window.hpp
+++ b/include/Gosu/Window.hpp
@@ -8,6 +8,14 @@
 
 namespace Gosu
 {
+    enum WindowFlags
+    {
+        WF_WINDOWED,
+        WF_FULLSCREEN = 1,
+        WF_RESIZABLE  = 2,
+        WF_BORDERLESS = 4
+    };
+
     //! Convenient all-in-one class that serves as the foundation of a standard Gosu application.
     //! Manages initialization of all of Gosu's core components and provides timing functionality.
     //! Note that you should really only use one instance of this class at the same time.
@@ -21,17 +29,23 @@ namespace Gosu
         //! \param width Width of the window in points; that is, pixels on a normal display, and
         //! 'points' on a high-resolution display.
         //! \param height See width.
+        //! \param window_flags A bitmask of values from Gosu::WindowFlags.
         //! \param update_interval Interval in milliseconds between two calls to the update member
         //! function.
-        Window(unsigned width, unsigned height, bool fullscreen = false,
-            double update_interval = 16.666666, bool resizable = false);
+        Window(int width, int height, unsigned window_flags = WF_WINDOWED,
+               double update_interval = 16.666666);
         virtual ~Window();
 
-        unsigned width() const;
-        unsigned height() const;
+        int width() const;
+        int height() const;
         bool fullscreen() const;
+        void resize(int width, int height, bool fullscreen);
+
         bool resizable() const;
-        void resize(unsigned width, unsigned height, bool fullscreen);
+        void set_resizable(bool resizable);
+
+        bool borderless() const;
+        void set_borderless(bool borderless);
 
         double update_interval() const;
         void set_update_interval(double update_interval);
@@ -129,22 +143,22 @@ namespace Gosu
     //! Returns the width (in pixels) of a screen.
     //! \param window The result describes the screen on which the window is shown, or the
     //!               primary screen if no window is given.
-    unsigned screen_width(Window* window = nullptr);
+    int screen_width(Window* window = nullptr);
 
     //! Returns the height (in pixels) of the user's primary screen.
     //! \param window The result describes the screen on which the window is shown, or the
     //!               primary screen if no window is given.
-    unsigned screen_height(Window* window = nullptr);
+    int screen_height(Window* window = nullptr);
 
     //! Returns the maximum width (in 'points') that is available for a non-fullscreen Window.
     //! All windows larger than this size will automatically be shrunk to fit.
     //! \param window The result describes the screen on which the window is shown, or the
     //!               primary screen if no window is given.
-    unsigned available_width(Window* window = nullptr);
+    int available_width(Window* window = nullptr);
 
     //! Returns the maximum height (in 'points') that is available for a non-fullscreen Window.
     //! All windows larger than this size will automatically be shrunk to fit.
     //! \param window The result describes the screen on which the window is shown, or the
     //!               primary screen if no window is given.
-    unsigned available_height(Window* window = nullptr);
+    int available_height(Window* window = nullptr);
 }

--- a/lib/gosu/swig_patches.rb
+++ b/lib/gosu/swig_patches.rb
@@ -3,19 +3,20 @@
 # compatible, but I just call protected_update etc. in the Ruby wrapper so I can add this
 # custom debugging help:
 class Gosu::Window
-  alias_method :initialize_without_hash, :initialize
+  alias_method :initialize_with_bitmask, :initialize
 
-  def initialize width, height, *args
-    if args.empty? or args.first.is_a? Hash
-      options = args.first || {}
-      fullscreen = options[:fullscreen]
-      update_interval = options[:update_interval]
-      resizable = options[:resizable]
-    else
-      fullscreen, update_interval = *args
-    end
+  def initialize(width, height, *args)
     $gosu_gl_blocks = nil
-    initialize_without_hash width, height, !!fullscreen, update_interval || 16.666666, !!resizable
+
+    if args.first.is_a? Hash
+      flags = 0
+      flags |= 1 if args.first[:fullscreen]
+      flags |= 2 if args.first[:resizable]
+      flags |= 4 if args.first[:borderless]
+      initialize_with_bitmask(width, height, flags, args.first[:update_interval] || 16.666666)
+    else
+      initialize_with_bitmask(width, height, args[0] ? 1 : 0, args[1] || 16.666666)
+    end
   end
 
   %w(update draw needs_redraw? needs_cursor?

--- a/rdoc/gosu.rb
+++ b/rdoc/gosu.rb
@@ -812,6 +812,18 @@ module Gosu
     def resizable?; end
 
     ##
+    # Toggles between resizable and fixed modes.
+    attr_writer :resizable
+
+    ##
+    # @return [true, false] whether this window is borderless.
+    def borderless?; end
+
+    ##
+    # Toggles between borderless mode and having window chrome.
+    attr_writer :borderless
+
+    ##
     # @return [Float] the interval between calls to {#update}, in milliseconds.
     attr_accessor :update_interval
 
@@ -828,7 +840,8 @@ module Gosu
     # @param height [Integer] the desired window height.
     # @param [Hash] options
     # @option options [true, false] :fullscreen (false) whether to present the window in fullscreen mode.
-    # @option options [true, false] :resizable (false) whether the window can be resized by the user.
+    # @option options [true, false] :resizable (false) whether the window can be resized by the user. Not useful if the window is either fullscreen or borderless.
+    # @option options [true, false] :borderless (false) whether the window should hide all its window chrome. Does not affect fullscreen windows.
     # @option options [Float] :update_interval (16.666666) the interval between frames, in milliseconds.
     def initialize(width, height, options); end
 

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -78,20 +78,11 @@ struct Gosu::Input::Impl
 
     void update_mouse_position()
     {
-    #if SDL_VERSION_ATLEAST(2, 0, 5)
-        // SDL_GetGlobalMouseState was added in SDL 2.0.4, but it only started using the same
-        // coordinate system as SDL_GetWindowPosition on X11 in 2.0.5.
         int x, y, window_x, window_y;
         SDL_GetWindowPosition(window, &window_x, &window_y);
         SDL_GetGlobalMouseState(&x, &y);
         mouse_x = x - window_x;
         mouse_y = y - window_y;
-    #else
-        int x, y;
-        SDL_GetMouseState(&x, &y);
-        mouse_x = x;
-        mouse_y = y;
-    #endif
     }
 
     void set_mouse_position(double x, double y)
@@ -100,7 +91,7 @@ struct Gosu::Input::Impl
                               static_cast<int>((x - mouse_offset_x) / mouse_scale_x),
                               static_cast<int>((y - mouse_offset_y) / mouse_scale_y));
 
-    #if SDL_VERSION_ATLEAST(2, 0, 4) && !defined(GOSU_IS_X)
+    #if !defined(GOSU_IS_X)
         // On systems where we have a working GetGlobalMouseState, we can warp the mouse and
         // retrieve its position directly afterwards.
         update_mouse_position();

--- a/src/Resolution.cpp
+++ b/src/Resolution.cpp
@@ -18,12 +18,12 @@ static SDL_DisplayMode display_mode(Gosu::Window* window)
     return result;
 }
 
-unsigned Gosu::screen_width(Window* window)
+int Gosu::screen_width(Window* window)
 {
     return display_mode(window).w;
 }
 
-unsigned Gosu::screen_height(Window* window)
+int Gosu::screen_height(Window* window)
 {
     return display_mode(window).h;
 }
@@ -41,12 +41,12 @@ static NSSize max_window_size(Gosu::Window* window)
     return [NSWindow contentRectForFrameRect:screen_frame styleMask:style].size;
 }
 
-unsigned Gosu::available_width(Window* window)
+int Gosu::available_width(Window* window)
 {
     return max_window_size(window).width;
 }
 
-unsigned Gosu::available_height(Window* window)
+int Gosu::available_height(Window* window)
 {
     return max_window_size(window).height;
 }
@@ -90,12 +90,12 @@ static SIZE max_window_size(Gosu::Window* window)
     return size;
 }
 
-unsigned Gosu::available_width(Window* window)
+int Gosu::available_width(Window* window)
 {
     return max_window_size(window).cx;
 }
 
-unsigned Gosu::available_height(Window* window)
+int Gosu::available_height(Window* window)
 {
     return max_window_size(window).cy;
 }
@@ -104,12 +104,12 @@ unsigned Gosu::available_height(Window* window)
 #ifdef GOSU_IS_X
 // Pessimistic fallback implementation for available_width / available_height.
 // TODO: Look at this NET_WORKAREA based implementation: https://github.com/glfw/glfw/pull/989/files
-unsigned Gosu::available_width(Window* window)
+int Gosu::available_width(Window* window)
 {
     return static_cast<unsigned>(Gosu::screen_width(window) * 0.9);
 }
 
-unsigned Gosu::available_height(Window* window)
+int Gosu::available_height(Window* window)
 {
     return static_cast<unsigned>(Gosu::screen_height(window) * 0.8);
 }

--- a/src/RubyGosu.cxx
+++ b/src/RubyGosu.cxx
@@ -12518,7 +12518,7 @@ SWIGEXPORT void Init_gosu(void) {
   rb_define_const(mGosu, "VERSION", SWIG_From_std_string(static_cast< std::string >(Gosu::VERSION)));
   rb_define_const(mGosu, "LICENSES", SWIG_From_std_string(static_cast< std::string >(Gosu::LICENSES)));
   rb_define_const(mGosu, "MAJOR_VERSION", SWIG_From_int(static_cast< int >(1)));
-  rb_define_const(mGosu, "MINOR_VERSION", SWIG_From_int(static_cast< int >(0)));
+  rb_define_const(mGosu, "MINOR_VERSION", SWIG_From_int(static_cast< int >(1)));
   rb_define_const(mGosu, "POINT_VERSION", SWIG_From_int(static_cast< int >(0)));
   rb_define_module_function(mGosu, "milliseconds", VALUEFUNC(_wrap_milliseconds), -1);
   rb_define_module_function(mGosu, "random", VALUEFUNC(_wrap_random), -1);

--- a/src/RubyGosu.cxx
+++ b/src/RubyGosu.cxx
@@ -3300,7 +3300,7 @@ std::string SwigDirector_TextInput::filter(std::string text) const {
 }
 
 
-SwigDirector_Window::SwigDirector_Window(VALUE self,unsigned int width,unsigned int height,bool fullscreen,double update_interval,bool resizable): Gosu::Window(width, height, fullscreen, update_interval, resizable), Swig::Director(self) {
+SwigDirector_Window::SwigDirector_Window(VALUE self,int width,int height,unsigned int window_flags,double update_interval): Gosu::Window(width, height, window_flags, update_interval), Swig::Director(self) {
   
 }
 
@@ -9198,44 +9198,41 @@ _wrap_Window_allocate(int argc, VALUE *argv, VALUE self)
 SWIGINTERN VALUE
 _wrap_new_Window(int argc, VALUE *argv, VALUE self) {
   VALUE arg1 = (VALUE) 0 ;
-  unsigned int arg2 ;
-  unsigned int arg3 ;
-  bool arg4 = (bool) false ;
+  int arg2 ;
+  int arg3 ;
+  unsigned int arg4 = (unsigned int) Gosu::WF_WINDOWED ;
   double arg5 = (double) 16.666666 ;
-  bool arg6 = (bool) false ;
-  unsigned int val2 ;
+  int val2 ;
   int ecode2 = 0 ;
-  unsigned int val3 ;
+  int val3 ;
   int ecode3 = 0 ;
-  bool val4 ;
+  unsigned int val4 ;
   int ecode4 = 0 ;
   double val5 ;
   int ecode5 = 0 ;
-  bool val6 ;
-  int ecode6 = 0 ;
   const char *classname SWIGUNUSED = "Gosu::Window";
   Gosu::Window *result = 0 ;
   
-  if ((argc < 2) || (argc > 5)) {
+  if ((argc < 2) || (argc > 4)) {
     rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
   }
   arg1 = self;
-  ecode2 = SWIG_AsVal_unsigned_SS_int(argv[0], &val2);
+  ecode2 = SWIG_AsVal_int(argv[0], &val2);
   if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "unsigned int","Window", 2, argv[0] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "int","Window", 2, argv[0] ));
   } 
-  arg2 = static_cast< unsigned int >(val2);
-  ecode3 = SWIG_AsVal_unsigned_SS_int(argv[1], &val3);
+  arg2 = static_cast< int >(val2);
+  ecode3 = SWIG_AsVal_int(argv[1], &val3);
   if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "unsigned int","Window", 3, argv[1] ));
+    SWIG_exception_fail(SWIG_ArgError(ecode3), Ruby_Format_TypeError( "", "int","Window", 3, argv[1] ));
   } 
-  arg3 = static_cast< unsigned int >(val3);
+  arg3 = static_cast< int >(val3);
   if (argc > 2) {
-    ecode4 = SWIG_AsVal_bool(argv[2], &val4);
+    ecode4 = SWIG_AsVal_unsigned_SS_int(argv[2], &val4);
     if (!SWIG_IsOK(ecode4)) {
-      SWIG_exception_fail(SWIG_ArgError(ecode4), Ruby_Format_TypeError( "", "bool","Window", 4, argv[2] ));
+      SWIG_exception_fail(SWIG_ArgError(ecode4), Ruby_Format_TypeError( "", "unsigned int","Window", 4, argv[2] ));
     } 
-    arg4 = static_cast< bool >(val4);
+    arg4 = static_cast< unsigned int >(val4);
   }
   if (argc > 3) {
     ecode5 = SWIG_AsVal_double(argv[3], &val5);
@@ -9244,20 +9241,13 @@ _wrap_new_Window(int argc, VALUE *argv, VALUE self) {
     } 
     arg5 = static_cast< double >(val5);
   }
-  if (argc > 4) {
-    ecode6 = SWIG_AsVal_bool(argv[4], &val6);
-    if (!SWIG_IsOK(ecode6)) {
-      SWIG_exception_fail(SWIG_ArgError(ecode6), Ruby_Format_TypeError( "", "bool","Window", 6, argv[4] ));
-    } 
-    arg6 = static_cast< bool >(val6);
-  }
   {
     try {
       if ( strcmp(rb_obj_classname(self), classname) != 0 ) {
         /* subclassed */
-        result = (Gosu::Window *)new SwigDirector_Window(arg1,arg2,arg3,arg4,arg5,arg6); 
+        result = (Gosu::Window *)new SwigDirector_Window(arg1,arg2,arg3,arg4,arg5); 
       } else {
-        result = (Gosu::Window *)new Gosu::Window(arg2,arg3,arg4,arg5,arg6); 
+        result = (Gosu::Window *)new Gosu::Window(arg2,arg3,arg4,arg5); 
       }
       
       DATA_PTR(self) = result;
@@ -9285,7 +9275,7 @@ _wrap_Window_width(int argc, VALUE *argv, VALUE self) {
   Gosu::Window *arg1 = (Gosu::Window *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  unsigned int result;
+  int result;
   VALUE vresult = Qnil;
   
   if ((argc < 0) || (argc > 0)) {
@@ -9298,13 +9288,13 @@ _wrap_Window_width(int argc, VALUE *argv, VALUE self) {
   arg1 = reinterpret_cast< Gosu::Window * >(argp1);
   {
     try {
-      result = (unsigned int)((Gosu::Window const *)arg1)->width();
+      result = (int)((Gosu::Window const *)arg1)->width();
     }
     catch (const std::exception& e) {
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  vresult = SWIG_From_unsigned_SS_int(static_cast< unsigned int >(result));
+  vresult = SWIG_From_int(static_cast< int >(result));
   return vresult;
 fail:
   return Qnil;
@@ -9316,7 +9306,7 @@ _wrap_Window_height(int argc, VALUE *argv, VALUE self) {
   Gosu::Window *arg1 = (Gosu::Window *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  unsigned int result;
+  int result;
   VALUE vresult = Qnil;
   
   if ((argc < 0) || (argc > 0)) {
@@ -9329,13 +9319,13 @@ _wrap_Window_height(int argc, VALUE *argv, VALUE self) {
   arg1 = reinterpret_cast< Gosu::Window * >(argp1);
   {
     try {
-      result = (unsigned int)((Gosu::Window const *)arg1)->height();
+      result = (int)((Gosu::Window const *)arg1)->height();
     }
     catch (const std::exception& e) {
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  vresult = SWIG_From_unsigned_SS_int(static_cast< unsigned int >(result));
+  vresult = SWIG_From_int(static_cast< int >(result));
   return vresult;
 fail:
   return Qnil;
@@ -9399,6 +9389,109 @@ _wrap_Window_resizableq___(int argc, VALUE *argv, VALUE self) {
   }
   vresult = SWIG_From_bool(static_cast< bool >(result));
   return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Window_resizablee___(int argc, VALUE *argv, VALUE self) {
+  Gosu::Window *arg1 = (Gosu::Window *) 0 ;
+  bool arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_Gosu__Window, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "Gosu::Window *","set_resizable", 1, self )); 
+  }
+  arg1 = reinterpret_cast< Gosu::Window * >(argp1);
+  ecode2 = SWIG_AsVal_bool(argv[0], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "bool","set_resizable", 2, argv[0] ));
+  } 
+  arg2 = static_cast< bool >(val2);
+  {
+    try {
+      (arg1)->set_resizable(arg2);
+    }
+    catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  return Qnil;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Window_borderlessq___(int argc, VALUE *argv, VALUE self) {
+  Gosu::Window *arg1 = (Gosu::Window *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_Gosu__Window, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "Gosu::Window const *","borderless", 1, self )); 
+  }
+  arg1 = reinterpret_cast< Gosu::Window * >(argp1);
+  {
+    try {
+      result = (bool)((Gosu::Window const *)arg1)->borderless();
+    }
+    catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  vresult = SWIG_From_bool(static_cast< bool >(result));
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Window_borderlesse___(int argc, VALUE *argv, VALUE self) {
+  Gosu::Window *arg1 = (Gosu::Window *) 0 ;
+  bool arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_Gosu__Window, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "Gosu::Window *","set_borderless", 1, self )); 
+  }
+  arg1 = reinterpret_cast< Gosu::Window * >(argp1);
+  ecode2 = SWIG_AsVal_bool(argv[0], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), Ruby_Format_TypeError( "", "bool","set_borderless", 2, argv[0] ));
+  } 
+  arg2 = static_cast< bool >(val2);
+  {
+    try {
+      (arg1)->set_borderless(arg2);
+    }
+    catch (const std::exception& e) {
+      SWIG_exception(SWIG_RuntimeError, e.what());
+    }
+  }
+  return Qnil;
 fail:
   return Qnil;
 }
@@ -10584,7 +10677,7 @@ _wrap_screen_width(int argc, VALUE *argv, VALUE self) {
   Gosu::Window *arg1 = (Gosu::Window *) nullptr ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  unsigned int result;
+  int result;
   VALUE vresult = Qnil;
   
   if ((argc < 0) || (argc > 1)) {
@@ -10599,13 +10692,13 @@ _wrap_screen_width(int argc, VALUE *argv, VALUE self) {
   }
   {
     try {
-      result = (unsigned int)Gosu::screen_width(arg1);
+      result = (int)Gosu::screen_width(arg1);
     }
     catch (const std::exception& e) {
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  vresult = SWIG_From_unsigned_SS_int(static_cast< unsigned int >(result));
+  vresult = SWIG_From_int(static_cast< int >(result));
   return vresult;
 fail:
   return Qnil;
@@ -10617,7 +10710,7 @@ _wrap_screen_height(int argc, VALUE *argv, VALUE self) {
   Gosu::Window *arg1 = (Gosu::Window *) nullptr ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  unsigned int result;
+  int result;
   VALUE vresult = Qnil;
   
   if ((argc < 0) || (argc > 1)) {
@@ -10632,13 +10725,13 @@ _wrap_screen_height(int argc, VALUE *argv, VALUE self) {
   }
   {
     try {
-      result = (unsigned int)Gosu::screen_height(arg1);
+      result = (int)Gosu::screen_height(arg1);
     }
     catch (const std::exception& e) {
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  vresult = SWIG_From_unsigned_SS_int(static_cast< unsigned int >(result));
+  vresult = SWIG_From_int(static_cast< int >(result));
   return vresult;
 fail:
   return Qnil;
@@ -10650,7 +10743,7 @@ _wrap_available_width(int argc, VALUE *argv, VALUE self) {
   Gosu::Window *arg1 = (Gosu::Window *) nullptr ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  unsigned int result;
+  int result;
   VALUE vresult = Qnil;
   
   if ((argc < 0) || (argc > 1)) {
@@ -10665,13 +10758,13 @@ _wrap_available_width(int argc, VALUE *argv, VALUE self) {
   }
   {
     try {
-      result = (unsigned int)Gosu::available_width(arg1);
+      result = (int)Gosu::available_width(arg1);
     }
     catch (const std::exception& e) {
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  vresult = SWIG_From_unsigned_SS_int(static_cast< unsigned int >(result));
+  vresult = SWIG_From_int(static_cast< int >(result));
   return vresult;
 fail:
   return Qnil;
@@ -10683,7 +10776,7 @@ _wrap_available_height(int argc, VALUE *argv, VALUE self) {
   Gosu::Window *arg1 = (Gosu::Window *) nullptr ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  unsigned int result;
+  int result;
   VALUE vresult = Qnil;
   
   if ((argc < 0) || (argc > 1)) {
@@ -10698,13 +10791,13 @@ _wrap_available_height(int argc, VALUE *argv, VALUE self) {
   }
   {
     try {
-      result = (unsigned int)Gosu::available_height(arg1);
+      result = (int)Gosu::available_height(arg1);
     }
     catch (const std::exception& e) {
       SWIG_exception(SWIG_RuntimeError, e.what());
     }
   }
-  vresult = SWIG_From_unsigned_SS_int(static_cast< unsigned int >(result));
+  vresult = SWIG_From_int(static_cast< int >(result));
   return vresult;
 fail:
   return Qnil;
@@ -12881,6 +12974,9 @@ SWIGEXPORT void Init_gosu(void) {
   rb_define_method(SwigClassWindow.klass, "height", VALUEFUNC(_wrap_Window_height), -1);
   rb_define_method(SwigClassWindow.klass, "fullscreen?", VALUEFUNC(_wrap_Window_fullscreenq___), -1);
   rb_define_method(SwigClassWindow.klass, "resizable?", VALUEFUNC(_wrap_Window_resizableq___), -1);
+  rb_define_method(SwigClassWindow.klass, "resizable=", VALUEFUNC(_wrap_Window_resizablee___), -1);
+  rb_define_method(SwigClassWindow.klass, "borderless?", VALUEFUNC(_wrap_Window_borderlessq___), -1);
+  rb_define_method(SwigClassWindow.klass, "borderless=", VALUEFUNC(_wrap_Window_borderlesse___), -1);
   rb_define_method(SwigClassWindow.klass, "update_interval", VALUEFUNC(_wrap_Window_update_interval), -1);
   rb_define_method(SwigClassWindow.klass, "update_interval=", VALUEFUNC(_wrap_Window_update_intervale___), -1);
   rb_define_method(SwigClassWindow.klass, "caption", VALUEFUNC(_wrap_Window_caption), -1);

--- a/src/RubyGosu.h
+++ b/src/RubyGosu.h
@@ -28,7 +28,7 @@ public:
 class SwigDirector_Window : public Gosu::Window, public Swig::Director {
 
 public:
-    SwigDirector_Window(VALUE self,unsigned int width,unsigned int height,bool fullscreen=false,double update_interval=16.666666,bool resizable=false);
+    SwigDirector_Window(VALUE self,int width,int height,unsigned int window_flags=Gosu::WF_WINDOWED,double update_interval=16.666666);
     virtual ~SwigDirector_Window();
     virtual void show();
     virtual bool tick();

--- a/src/TrueTypeFontWin.cpp
+++ b/src/TrueTypeFontWin.cpp
@@ -32,9 +32,9 @@ const unsigned char* Gosu::ttf_data_by_name(const string& font_name, unsigned fo
     LOGFONT logfont = {
         0, 0, 0, 0,
         (font_flags & Gosu::FF_BOLD) ? FW_BOLD : FW_NORMAL,
-        (font_flags & Gosu::FF_ITALIC) ? TRUE : FALSE,
-        (font_flags & Gosu::FF_UNDERLINE) ? TRUE : FALSE,
-        FALSE /* no strikethrough */,
+        static_cast<BYTE>((font_flags & Gosu::FF_ITALIC) ? TRUE : FALSE),
+        static_cast<BYTE>((font_flags & Gosu::FF_UNDERLINE) ? TRUE : FALSE),
+        0 /* no strikethrough */,
         ANSI_CHARSET, OUT_OUTLINE_PRECIS, CLIP_DEFAULT_PRECIS, ANTIALIASED_QUALITY,
         DEFAULT_PITCH
     };

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -34,11 +34,7 @@ namespace Gosu
                 throw_sdl_error("Could not initialize SDL Video");
             }
 
-            Uint32 flags = SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN;
-
-        #if SDL_VERSION_ATLEAST(2, 0, 1)
-            flags |= SDL_WINDOW_ALLOW_HIGHDPI;
-        #endif
+            Uint32 flags = SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN | SDL_WINDOW_ALLOW_HIGHDPI;
 
             window =
                 SDL_CreateWindow("", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 64, 64, flags);
@@ -192,9 +188,7 @@ void Gosu::Window::resize(int width, int height, bool fullscreen)
         SDL_SetWindowSize(shared_window(), actual_width, actual_height);
     }
 
-#if SDL_VERSION_ATLEAST(2, 0, 1)
     SDL_GL_GetDrawableSize(shared_window(), &actual_width, &actual_height);
-#endif
 
     ensure_current_context();
 
@@ -221,9 +215,7 @@ bool Gosu::Window::resizable() const
 void Gosu::Window::set_resizable(bool resizable)
 {
     pimpl->resizable = resizable;
-#if SDL_VERSION_ATLEAST(2, 0, 5)
     SDL_SetWindowResizable(shared_window(), resizable ? SDL_TRUE : SDL_FALSE);
-#endif
 }
 
 bool Gosu::Window::borderless() const

--- a/src/WindowUIKit.cpp
+++ b/src/WindowUIKit.cpp
@@ -17,8 +17,7 @@ struct Gosu::Window::Impl
     string caption;
 };
 
-Gosu::Window::Window(unsigned width, unsigned height, bool fullscreen, double update_interval,
-                     bool resizable)
+Gosu::Window::Window(int width, int height, unsigned window_flags, double update_interval)
 : pimpl(new Impl)
 {
     pimpl->window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
@@ -50,12 +49,12 @@ Gosu::Window::~Window()
 {
 }
 
-unsigned Gosu::Window::width() const
+int Gosu::Window::width() const
 {
     return graphics().width();
 }
 
-unsigned Gosu::Window::height() const
+int Gosu::Window::height() const
 {
     return graphics().height();
 }
@@ -70,7 +69,20 @@ bool Gosu::Window::resizable() const
     return false;
 }
 
-void Gosu::Window::resize(unsigned width, unsigned height, bool fullscreen)
+void Gosu::Window::set_resizable(bool resizable)
+{
+}
+
+bool Gosu::Window::borderless() const
+{
+    return true;
+}
+
+void Gosu::Window::set_borderless(bool borderless)
+{
+}
+
+void Gosu::Window::resize(int width, int height, bool fullscreen)
 {
     throw logic_error("Cannot resize windows on iOS");
 }
@@ -138,24 +150,24 @@ void* Gosu::Window::uikit_window() const
     return (__bridge void*) pimpl->window;
 }
 
-unsigned Gosu::screen_width(Window*)
+int Gosu::screen_width(Window*)
 {
     return available_width() * [UIScreen mainScreen].scale;
 }
 
-unsigned Gosu::screen_height(Window*)
+int Gosu::screen_height(Window*)
 {
     return available_height() * [UIScreen mainScreen].scale;
 }
 
-unsigned Gosu::available_width(Window*)
+int Gosu::available_width(Window*)
 {
     static CGSize screen_size = [UIScreen mainScreen].bounds.size;
     static CGFloat width = MAX(screen_size.width, screen_size.height);
     return width;
 }
 
-unsigned Gosu::available_height(Window*)
+int Gosu::available_height(Window*)
 {
     static CGSize screen_size = [UIScreen mainScreen].bounds.size;
     static CGFloat height = MIN(screen_size.width, screen_size.height);

--- a/windows/GosuFFI.vcxproj
+++ b/windows/GosuFFI.vcxproj
@@ -23,6 +23,7 @@
     <ClInclude Include="..\ffi\Gosu_Channel.h" />
     <ClInclude Include="..\ffi\Gosu_Color.h" />
     <ClInclude Include="..\ffi\Gosu_FFI.h" />
+    <ClInclude Include="..\ffi\Gosu_FFI_internal.h" />
     <ClInclude Include="..\ffi\Gosu_Font.h" />
     <ClInclude Include="..\ffi\Gosu_Image.h" />
     <ClInclude Include="..\ffi\Gosu_Sample.h" />

--- a/windows/GosuFFI.vcxproj.filters
+++ b/windows/GosuFFI.vcxproj.filters
@@ -23,6 +23,9 @@
     <ClInclude Include="..\ffi\Gosu_FFI.h">
       <Filter>Interface</Filter>
     </ClInclude>
+    <ClInclude Include="..\ffi\Gosu_FFI_internal.h">
+      <Filter>Interface</Filter>
+    </ClInclude>
     <ClInclude Include="..\ffi\Gosu_Font.h">
       <Filter>Interface</Filter>
     </ClInclude>


### PR DESCRIPTION
FYI @cyberarm this includes the WindowFlags / borderless changes from #555. I didn't want to merge the other parts without more time to actually test the changes on all platforms.

Due to the way I'm calling Window::set_resizable from the start of the constructor, this should also practically include the first fix from https://github.com/gosu/gosu/pull/541/files.

Bumped the version to 1.1.0 due to the large FFI-related changes in this PR and the previous ones.