### PR TITLE
Add FFI error reporting

### DIFF
--- a/ffi/Gosu.cpp
+++ b/ffi/Gosu.cpp
@@ -1,31 +1,53 @@
 #include "Gosu_FFI_internal.h"
 
+std::string& Gosu_internal_error()
+{
+    static thread_local std::string error;
+    return error;
+}
+
+GOSU_FFI_API const char* Gosu_last_error(void)
+{
+    return Gosu_internal_error().empty() ? nullptr : Gosu_internal_error().c_str();
+}
+
 GOSU_FFI_API void Gosu_gl_z(double z, void function(void*), void* data)
 {
-    Gosu::Graphics::gl(z, [=]() { function(data); });
+    Gosu_translate_exceptions([=] {
+        Gosu::Graphics::gl(z, [=] { function(data); });
+    });
 }
 
 GOSU_FFI_API void Gosu_gl(void function(void*), void* data)
 {
-    Gosu::Graphics::gl([=] { function(data); });
+    Gosu_translate_exceptions([=] {
+        Gosu::Graphics::gl([=] { function(data); });
+    });
 }
 
 GOSU_FFI_API Gosu_Image* Gosu_render(int width, int height, void function(void*), void* data,
                                      unsigned image_flags)
 {
-    Gosu::Image image = Gosu::Graphics::render(width, height, [=] { function(data); }, image_flags);
-    return new Gosu_Image{image};
+    return Gosu_translate_exceptions([=] {
+        Gosu::Image image = Gosu::Graphics::render(width, height, [=] { function(data); },
+                                                   image_flags);
+        return new Gosu_Image{image};
+    });
 }
 
 GOSU_FFI_API Gosu_Image* Gosu_record(int width, int height, void function(void*), void* data)
 {
-    Gosu::Image image = Gosu::Graphics::record(width, height, [=] { function(data); });
-    return new Gosu_Image{image};
+    return Gosu_translate_exceptions([=] {
+        Gosu::Image image = Gosu::Graphics::record(width, height, [=] { function(data); });
+        return new Gosu_Image{image};
+    });
 }
 
 GOSU_FFI_API void Gosu_flush(void)
 {
-    Gosu::Graphics::flush();
+    Gosu_translate_exceptions([=] {
+        Gosu::Graphics::flush();
+    });
 }
 
 GOSU_FFI_API void Gosu_transform(double m0, double m1, double m2, double m3, double m4, double m5,
@@ -33,169 +55,231 @@ GOSU_FFI_API void Gosu_transform(double m0, double m1, double m2, double m3, dou
                                  double m12, double m13, double m14, double m15,
                                  void function(void*), void* data)
 {
-    Gosu::Transform transform = {m0, m1, m2,  m3,  m4,  m5,  m6,  m7,
-                                 m8, m9, m10, m11, m12, m13, m14, m15};
-    Gosu::Graphics::transform(transform, [=] { function(data); });
+    Gosu_translate_exceptions([=] {
+        Gosu::Transform transform = {m0, m1, m2,  m3,  m4,  m5,  m6,  m7,
+                                     m8, m9, m10, m11, m12, m13, m14, m15};
+        Gosu::Graphics::transform(transform, [=] { function(data); });
+    });
 }
 
 GOSU_FFI_API void Gosu_translate(double x, double y, void function(void*), void* data)
 {
-    Gosu::Graphics::transform(Gosu::translate(x, y), [=] { function(data); });
+    Gosu_translate_exceptions([=] {
+        Gosu::Graphics::transform(Gosu::translate(x, y), [=] { function(data); });
+    });
 }
 
 GOSU_FFI_API void Gosu_scale(double scale_x, double scale_y, double around_x, double around_y,
                              void function(void*), void* data)
 {
-    Gosu::Graphics::transform(Gosu::scale(scale_x, scale_y, around_x, around_y),
-                              [=] { function(data); });
+    Gosu_translate_exceptions([=] {
+        Gosu::Graphics::transform(Gosu::scale(scale_x, scale_y, around_x, around_y),
+                                  [=] { function(data); });
+    });
 }
 
 GOSU_FFI_API void Gosu_rotate(double angle, double around_x, double around_y, void function(void*),
                               void* data)
 {
-    Gosu::Graphics::transform(Gosu::rotate(angle, around_x, around_y), [=] { function(data); });
+    Gosu_translate_exceptions([=] {
+        Gosu::Graphics::transform(Gosu::rotate(angle, around_x, around_y), [=] { function(data); });
+    });
 }
 
 GOSU_FFI_API void Gosu_clip_to(double x, double y, double width, double height,
                                void function(void*), void* data)
 {
-    Gosu::Graphics::clip_to(x, y, width, height, [=] { function(data); });
+    Gosu_translate_exceptions([=] {
+        Gosu::Graphics::clip_to(x, y, width, height, [=] { function(data); });
+    });
 }
 
 GOSU_FFI_API void Gosu_draw_line(double x1, double y1, unsigned c1, double x2, double y2,
                                  unsigned c2, double z, unsigned mode)
 {
-    Gosu::Graphics::draw_line(x1, y1, c1, x2, y2, c2, z, static_cast<Gosu::BlendMode>(mode));
+    Gosu_translate_exceptions([=] {
+        Gosu::Graphics::draw_line(x1, y1, c1, x2, y2, c2, z, static_cast<Gosu::BlendMode>(mode));
+    });
 }
 
 GOSU_FFI_API void Gosu_draw_triangle(double x1, double y1, unsigned c1, double x2, double y2,
                                      unsigned c2, double x3, double y3, unsigned c3, double z,
                                      unsigned mode)
 {
-    Gosu::Graphics::draw_triangle(x1, y1, c1, x2, y2, c2, x3, y3, c3, z,
-                                  static_cast<Gosu::BlendMode>(mode));
+    Gosu_translate_exceptions([=] {
+        Gosu::Graphics::draw_triangle(x1, y1, c1, x2, y2, c2, x3, y3, c3, z,
+                                      static_cast<Gosu::BlendMode>(mode));
+    });
 }
 
 GOSU_FFI_API void Gosu_draw_rect(double x, double y, double width, double height, unsigned c,
                                  double z, unsigned mode)
 {
-    Gosu::Graphics::draw_rect(x, y, width, height, c, z, static_cast<Gosu::BlendMode>(mode));
+    Gosu_translate_exceptions([=] {
+        Gosu::Graphics::draw_rect(x, y, width, height, c, z, static_cast<Gosu::BlendMode>(mode));
+    });
 }
 
 GOSU_FFI_API void Gosu_draw_quad(double x1, double y1, unsigned c1, double x2, double y2,
                                  unsigned c2, double x3, double y3, unsigned c3, double x4,
                                  double y4, unsigned c4, double z, unsigned mode)
 {
-    Gosu::Graphics::draw_quad(x1, y1, c1, x2, y2, c2, x3, y3, c3, x4, y4, c4, z,
-                              static_cast<Gosu::BlendMode>(mode));
+    Gosu_translate_exceptions([=] {
+        Gosu::Graphics::draw_quad(x1, y1, c1, x2, y2, c2, x3, y3, c3, x4, y4, c4, z,
+                                  static_cast<Gosu::BlendMode>(mode));
+    });
 }
 
 GOSU_FFI_API double Gosu_distance(double x1, double y1, double x2, double y2)
 {
-    return Gosu::distance(x1, y1, x2, y2);
+    return Gosu_translate_exceptions([=] {
+        return Gosu::distance(x1, y1, x2, y2);
+    });
 }
 
 GOSU_FFI_API double Gosu_angle(double from_x, double from_y, double to_x, double to_y)
 {
-    return Gosu::angle(from_x, from_y, to_x, to_y);
+    return Gosu_translate_exceptions([=] {
+        return Gosu::angle(from_x, from_y, to_x, to_y);
+    });
 }
 
 GOSU_FFI_API double Gosu_angle_diff(double from, double to)
 {
-    return Gosu::angle_diff(from, to);
+    return Gosu_translate_exceptions([=] {
+        return Gosu::angle_diff(from, to);
+    });
 }
 
 GOSU_FFI_API double Gosu_offset_x(double angle, double radius)
 {
-    return Gosu::offset_x(angle, radius);
+    return Gosu_translate_exceptions([=] {
+        return Gosu::offset_x(angle, radius);
+    });
 }
 
 GOSU_FFI_API double Gosu_offset_y(double angle, double radius)
 {
-    return Gosu::offset_y(angle, radius);
+    return Gosu_translate_exceptions([=] {
+        return Gosu::offset_y(angle, radius);
+    });
 }
 
 GOSU_FFI_API double Gosu_random(double min, double max)
 {
-    return Gosu::random(min, max);
+    return Gosu_translate_exceptions([=] {
+        return Gosu::random(min, max);
+    });
 }
 
 GOSU_FFI_API int Gosu_available_width(Gosu_Window* window)
 {
-    return Gosu::available_width(window);
+    return Gosu_translate_exceptions([=] {
+        return Gosu::available_width(window);
+    });
 }
 
 GOSU_FFI_API int Gosu_available_height(Gosu_Window* window)
 {
-    return Gosu::available_height(window);
+    return Gosu_translate_exceptions([=] {
+        return Gosu::available_height(window);
+    });
 }
 
 GOSU_FFI_API int Gosu_screen_width(Gosu_Window* window)
 {
-    return Gosu::screen_width(window);
+    return Gosu_translate_exceptions([=] {
+        return Gosu::screen_width(window);
+    });
 }
 
 GOSU_FFI_API int Gosu_screen_height(Gosu_Window* window)
 {
-    return Gosu::screen_height(window);
+    return Gosu_translate_exceptions([=] {
+        return Gosu::screen_height(window);
+    });
 }
 
 GOSU_FFI_API int Gosu_button_down(int id)
 {
-    return Gosu::Input::down(static_cast<Gosu::Button>(id));
+    return Gosu_translate_exceptions([=] {
+        return Gosu::Input::down(static_cast<Gosu::Button>(id));
+    });
 }
 
 GOSU_FFI_API const char* Gosu_button_id_to_char(int id)
 {
     static thread_local std::string button;
-    button = Gosu::Input::id_to_char(static_cast<Gosu::Button>(id));
-    return button.c_str();
+
+    return Gosu_translate_exceptions([=] {
+        button = Gosu::Input::id_to_char(static_cast<Gosu::Button>(id));
+        return button.c_str();
+    });
 }
 
 GOSU_FFI_API unsigned Gosu_button_char_to_id(const char* btn)
 {
-    return Gosu::Input::char_to_id(btn);
+    return Gosu_translate_exceptions([=] {
+        return Gosu::Input::char_to_id(btn);
+    });
 }
 
 GOSU_FFI_API const char* Gosu_button_name(int id)
 {
     static thread_local std::string name;
-    name = Gosu::Input::button_name(static_cast<Gosu::Button>(id));
-    return name.empty() ? nullptr : name.c_str();
+
+    return Gosu_translate_exceptions([=] {
+        name = Gosu::Input::button_name(static_cast<Gosu::Button>(id));
+        return name.empty() ? nullptr : name.c_str();
+    });
 }
 
 GOSU_FFI_API const char* Gosu_gamepad_name(int id)
 {
     static thread_local std::string name;
-    name = Gosu::Input::gamepad_name(id);
-    return name.empty() ? nullptr : name.c_str();
+
+    return Gosu_translate_exceptions([=] {
+        name = Gosu::Input::gamepad_name(id);
+        return name.empty() ? nullptr : name.c_str();
+    });
 }
 
 GOSU_FFI_API double Gosu_axis(int id)
 {
-    return Gosu::Input::axis(static_cast<Gosu::Button>(id));
+    return Gosu_translate_exceptions([=] {
+        return Gosu::Input::axis(static_cast<Gosu::Button>(id));
+    });
 }
 
 GOSU_FFI_API int Gosu_fps()
 {
-    return Gosu::fps();
+    return Gosu_translate_exceptions([=] {
+        return Gosu::fps();
+    });
 }
 
 GOSU_FFI_API void Gosu_get_user_languages(void function(void*, const char*), void* data)
 {
-    for (const std::string& user_language : Gosu::user_languages()) {
-        function(data, user_language.c_str());
-    }
+    Gosu_translate_exceptions([=] {
+        for (const std::string& user_language : Gosu::user_languages()) {
+            function(data, user_language.c_str());
+        }
+    });
 }
 
 GOSU_FFI_API uint64_t Gosu_milliseconds()
 {
-    return Gosu::milliseconds();
+    return Gosu_translate_exceptions([=] {
+        return Gosu::milliseconds();
+    });
 }
 
 GOSU_FFI_API const char* Gosu_default_font_name()
 {
     static thread_local std::string name;
-    name = Gosu::default_font_name();
-    return name.c_str();
+
+    return Gosu_translate_exceptions([=] {
+        name = Gosu::default_font_name();
+        return name.c_str();
+    });
 }

--- a/ffi/Gosu.h
+++ b/ffi/Gosu.h
@@ -11,6 +11,9 @@
 #include "Gosu_Window.h"
 #include <stdint.h>
 
+// Error reporting
+GOSU_FFI_API const char* Gosu_last_error(void);
+
 // Graphics operations
 GOSU_FFI_API void Gosu_gl_z(double z, void function(void* data), void* data);
 GOSU_FFI_API void Gosu_gl(void function(void* data), void* data);

--- a/ffi/Gosu_Channel.cpp
+++ b/ffi/Gosu_Channel.cpp
@@ -2,45 +2,63 @@
 
 GOSU_FFI_API void Gosu_Channel_destroy(Gosu_Channel* channel)
 {
-    delete channel;
+    Gosu_translate_exceptions([=] {
+        delete channel;
+    });
 }
 
 GOSU_FFI_API bool Gosu_Channel_playing(Gosu_Channel* channel)
 {
-    return channel->channel.playing();
+    return Gosu_translate_exceptions([=] {
+        return channel->channel.playing();
+    });
 }
 
 GOSU_FFI_API void Gosu_Channel_pause(Gosu_Channel* channel)
 {
-    channel->channel.pause();
+    Gosu_translate_exceptions([=] {
+        channel->channel.pause();
+    });
 }
 
 GOSU_FFI_API bool Gosu_Channel_paused(Gosu_Channel* channel)
 {
-    return channel->channel.paused();
+    return Gosu_translate_exceptions([=] {
+        return channel->channel.paused();
+    });
 }
 
 GOSU_FFI_API void Gosu_Channel_resume(Gosu_Channel* channel)
 {
-    channel->channel.resume();
+    Gosu_translate_exceptions([=] {
+        channel->channel.resume();
+    });
 }
 
 GOSU_FFI_API void Gosu_Channel_stop(Gosu_Channel* channel)
 {
-    channel->channel.stop();
+    Gosu_translate_exceptions([=] {
+        channel->channel.stop();
+    });
 }
 
 GOSU_FFI_API void Gosu_Channel_set_volume(Gosu_Channel* channel, double volume)
 {
-    channel->channel.set_volume(volume);
+    Gosu_translate_exceptions([=] {
+        channel->channel.set_volume(volume);
+    });
 }
 
 GOSU_FFI_API void Gosu_Channel_set_speed(Gosu_Channel* channel, double speed)
 {
-    channel->channel.set_speed(speed);
+    Gosu_translate_exceptions([=] {
+        channel->channel.set_speed(speed);
+    });
 }
 
 GOSU_FFI_API void Gosu_Channel_set_pan(Gosu_Channel* channel, double pan)
 {
-    channel->channel.set_pan(pan);
+    Gosu_translate_exceptions([=] {
+        channel->channel.set_pan(pan);
+    });
 }

--- a/ffi/Gosu_Constants.cpp
+++ b/ffi/Gosu_Constants.cpp
@@ -20,7 +20,7 @@ GOSU_FFI_API const unsigned Gosu_WF_FULLSCREEN = Gosu::WF_FULLSCREEN;
 GOSU_FFI_API const unsigned Gosu_WF_RESIZABLE = Gosu::WF_RESIZABLE;
 GOSU_FFI_API const unsigned Gosu_WF_BORDERLESS = Gosu::WF_BORDERLESS;
 
-// Alpha/Blend Modes
+// Blend Modes
 GOSU_FFI_API const unsigned Gosu_BM_DEFAULT = Gosu::BM_DEFAULT;
 GOSU_FFI_API const unsigned Gosu_BM_INTERPOLATE = Gosu::BM_INTERPOLATE;
 GOSU_FFI_API const unsigned Gosu_BM_ADD = Gosu::BM_ADD;

--- a/ffi/Gosu_FFI_internal.h
+++ b/ffi/Gosu_FFI_internal.h
@@ -6,6 +6,27 @@
 
 #include "Gosu.h"
 #include <Gosu/Gosu.hpp>
+#include <stdexcept>
+
+// Error handling
+
+std::string& Gosu_internal_error();
+
+template<typename Functor>
+auto Gosu_translate_exceptions(Functor functor)
+{
+    try {
+        Gosu_internal_error().clear();
+        return functor();
+    }
+    catch (const std::exception& e) {
+        Gosu_internal_error() = e.what();
+        using R = decltype(functor());
+        return R();
+    }
+}
+
+// C-compatible wrapper structs for Gosu classes
 
 struct Gosu_Channel
 {
@@ -26,6 +47,8 @@ struct Gosu_Sample
 {
     Gosu::Sample sample;
 };
+
+// Use inheritance where composition is not feasible
 
 struct Gosu_Song : Gosu::Song
 {

--- a/ffi/Gosu_Font.cpp
+++ b/ffi/Gosu_Font.cpp
@@ -2,74 +2,100 @@
 
 GOSU_FFI_API Gosu_Font* Gosu_Font_create(int height, const char* name, unsigned flags)
 {
-    return new Gosu_Font{Gosu::Font{height, name, flags}};
+    return Gosu_translate_exceptions([=] {
+        return new Gosu_Font{Gosu::Font{height, name, flags}};
+    });
 }
 
 GOSU_FFI_API void Gosu_Font_destroy(Gosu_Font* font)
 {
-    delete font;
+    Gosu_translate_exceptions([=] {
+        delete font;
+    });
 }
 
 GOSU_FFI_API const char* Gosu_Font_name(Gosu_Font* font)
 {
     static thread_local std::string name;
-    name = font->font.name();
-    return name.c_str();
+
+    return Gosu_translate_exceptions([=] {
+        name = font->font.name();
+        return name.c_str();
+    });
 }
 
 GOSU_FFI_API int Gosu_Font_height(Gosu_Font* font)
 {
-    return font->font.height();
+    return Gosu_translate_exceptions([=] {
+        return font->font.height();
+    });
 }
 
 GOSU_FFI_API unsigned Gosu_Font_flags(Gosu_Font* font)
 {
-    return font->font.flags();
+    return Gosu_translate_exceptions([=] {
+        return font->font.flags();
+    });
 }
 
 GOSU_FFI_API double Gosu_Font_text_width(Gosu_Font* font, const char* text)
 {
-    return font->font.text_width(text);
+    return Gosu_translate_exceptions([=] {
+        return font->font.text_width(text);
+    });
 }
 
 GOSU_FFI_API double Gosu_Font_markup_width(Gosu_Font* font, const char* markup)
 {
-    return font->font.markup_width(markup);
+    return Gosu_translate_exceptions([=] {
+        return font->font.markup_width(markup);
+    });
 }
 
 GOSU_FFI_API void Gosu_Font_draw_text(Gosu_Font* font, const char* text, double x, double y,
                                       double z, double scale_x, double scale_y, unsigned c,
                                       unsigned mode)
 {
-    font->font.draw_text(text, x, y, z, scale_x, scale_y, c, static_cast<Gosu::BlendMode>(mode));
+    Gosu_translate_exceptions([=] {
+        font->font.draw_text(text, x, y, z, scale_x, scale_y, c,
+                             static_cast<Gosu::BlendMode>(mode));
+    });
 }
 
 GOSU_FFI_API void Gosu_Font_draw_markup(Gosu_Font* font, const char* markup, double x, double y,
                                         double z, double scale_x, double scale_y, unsigned c,
                                         unsigned mode)
 {
-    font->font.draw_markup(markup, x, y, z, scale_x, scale_y, c,
-                           static_cast<Gosu::BlendMode>(mode));
+    Gosu_translate_exceptions([=] {
+        font->font.draw_markup(markup, x, y, z, scale_x, scale_y, c,
+                               static_cast<Gosu::BlendMode>(mode));
+    });
 }
 
 GOSU_FFI_API void Gosu_Font_draw_text_rel(Gosu_Font* font, const char* text, double x, double y,
                                           double z, double rel_x, double rel_y, double scale_x,
                                           double scale_y, unsigned c, unsigned mode)
 {
-    font->font.draw_text_rel(text, x, y, z, rel_x, rel_y, scale_x, scale_y, c,
-                             static_cast<Gosu::BlendMode>(mode));
+    Gosu_translate_exceptions([=] {
+        font->font.draw_text_rel(text, x, y, z, rel_x, rel_y, scale_x, scale_y, c,
+                                 static_cast<Gosu::BlendMode>(mode));
+    });
 }
 
 GOSU_FFI_API void Gosu_Font_draw_markup_rel(Gosu_Font* font, const char* markup, double x, double y,
                                             double z, double rel_x, double rel_y, double scale_x,
                                             double scale_y, unsigned c, unsigned mode)
 {
-    font->font.draw_markup_rel(markup, x, y, z, rel_x, rel_y, scale_x, scale_y, c,
-                               static_cast<Gosu::BlendMode>(mode));
+    Gosu_translate_exceptions([=] {
+        font->font.draw_markup_rel(markup, x, y, z, rel_x, rel_y, scale_x, scale_y, c,
+                                   static_cast<Gosu::BlendMode>(mode));
+    });
 }
 
 GOSU_FFI_API void Gosu_Font_set_image(Gosu_Font* font, const char* codepoint, unsigned font_flags,
                                       Gosu_Image* image)
 {
-    font->font.set_image(codepoint, font_flags, image->image);
+    Gosu_translate_exceptions([=] {
+        font->font.set_image(codepoint, font_flags, image->image);
+    });
 }

--- a/ffi/Gosu_Image.cpp
+++ b/ffi/Gosu_Image.cpp
@@ -1,9 +1,11 @@
 #include "Gosu_FFI_internal.h"
-#include <cstring>
+#include <cstring> // for std::memcpy
 
 GOSU_FFI_API Gosu_Image* Gosu_Image_create(const char* filename, unsigned image_flags)
 {
-    return new Gosu_Image{Gosu::Image{filename, image_flags}};
+    return Gosu_translate_exceptions([=] {
+        return new Gosu_Image{Gosu::Image{filename, image_flags}};
+    });
 }
 
 GOSU_FFI_API Gosu_Image* Gosu_Image_create_from_markup(const char* markup, const char* font,
@@ -11,9 +13,11 @@ GOSU_FFI_API Gosu_Image* Gosu_Image_create_from_markup(const char* markup, const
                                                        double spacing, unsigned align,
                                                        unsigned font_flags, unsigned image_flags)
 {
-    Gosu::Bitmap bitmap = Gosu::layout_markup(markup, font, font_height, spacing, width,
-                                              static_cast<Gosu::Alignment>(align), font_flags);
-    return new Gosu_Image{Gosu::Image{bitmap, image_flags}};
+    return Gosu_translate_exceptions([=] {
+        Gosu::Bitmap bitmap = Gosu::layout_markup(markup, font, font_height, spacing, width,
+                                                  static_cast<Gosu::Alignment>(align), font_flags);
+        return new Gosu_Image{Gosu::Image{bitmap, image_flags}};
+    });
 }
 
 GOSU_FFI_API Gosu_Image* Gosu_Image_create_from_text(const char* text, const char* font,
@@ -21,59 +25,67 @@ GOSU_FFI_API Gosu_Image* Gosu_Image_create_from_text(const char* text, const cha
                                                      unsigned align, unsigned font_flags,
                                                      unsigned image_flags)
 {
-    Gosu::Bitmap bitmap = Gosu::layout_text(text, font, font_height, spacing, width,
-                                            static_cast<Gosu::Alignment>(align), font_flags);
-    return new Gosu_Image{Gosu::Image{bitmap, image_flags}};
+    return Gosu_translate_exceptions([=] {
+        Gosu::Bitmap bitmap = Gosu::layout_text(text, font, font_height, spacing, width,
+                                                static_cast<Gosu::Alignment>(align), font_flags);
+        return new Gosu_Image{Gosu::Image{bitmap, image_flags}};
+    });
 }
 
 GOSU_FFI_API Gosu_Image* Gosu_Image_create_from_blob(void* blob, int byte_count, int columns,
                                                      int rows, unsigned image_flags)
 {
-    std::size_t size = columns * rows * 4;
-    Gosu::Bitmap bitmap{columns, rows};
+    return Gosu_translate_exceptions([=] {
+        std::size_t size = columns * rows * 4;
+        Gosu::Bitmap bitmap{columns, rows};
 
-    if (byte_count == size) {
-        // 32 bit per pixel, assume R8G8B8A8
-        std::memcpy(bitmap.data(), blob, size);
-    }
-    else if (byte_count == size * sizeof(float)) {
-        // 128 bit per channel, assume float/float/float/float - for Texplay compatibility.
-        const float* in = static_cast<const float*>(blob);
-        Gosu::Color::Channel* out = reinterpret_cast<Gosu::Color::Channel*>(bitmap.data());
-        for (std::size_t i = 0; i < size; ++i) {
-            out[i] = static_cast<Gosu::Color::Channel>(in[i] * 255);
+        if (byte_count == size) {
+            // 32 bit per pixel, assume R8G8B8A8
+            std::memcpy(bitmap.data(), blob, size);
         }
-    }
-    else {
-        return nullptr; // abort?
-    }
+        else if (byte_count == size * sizeof(float)) {
+            // 128 bit per channel, assume float/float/float/float - for Texplay compatibility.
+            const float* in = static_cast<const float*>(blob);
+            Gosu::Color::Channel* out = reinterpret_cast<Gosu::Color::Channel*>(bitmap.data());
+            for (std::size_t i = 0; i < size; ++i) {
+                out[i] = static_cast<Gosu::Color::Channel>(in[i] * 255);
+            }
+        }
+        else {
+            throw std::invalid_argument{"Invalid byte_count " + std::to_string(byte_count) +
+                                        "for image of size " + std::to_string(columns) + "x" +
+                                        std::to_string(rows)};
+        }
 
-    return new Gosu_Image{Gosu::Image{bitmap, image_flags}};
+        return new Gosu_Image{Gosu::Image{bitmap, image_flags}};
+    });
 }
 
 GOSU_FFI_API Gosu_Image* Gosu_Image_create_from_subimage(Gosu_Image* image, int left, int top,
                                                          int width, int height)
 {
-    std::unique_ptr<Gosu::ImageData> image_data =
+    return Gosu_translate_exceptions([=]() -> Gosu_Image* {
+        std::unique_ptr<Gosu::ImageData> image_data =
             image->image.data().subimage(left, top, width, height);
 
-    if (!image_data) {
-        return nullptr;
-    }
+        if (image_data) return nullptr;
 
-    return new Gosu_Image{Gosu::Image{std::move(image_data)}};
+        return new Gosu_Image{Gosu::Image{std::move(image_data)}};
+    });
 }
 
 GOSU_FFI_API void Gosu_Image_create_from_tiles(const char* source, int tile_width, int tile_height,
                                                void function(void*, Gosu_Image*), void* data,
                                                unsigned image_flags)
 {
-    std::vector<Gosu::Image> gosu_images =
+    Gosu_translate_exceptions([=] {
+        std::vector<Gosu::Image> gosu_images =
             Gosu::load_tiles(source, tile_width, tile_height, image_flags);
 
-    for (Gosu::Image& img : gosu_images) {
-        function(data, new Gosu_Image{img});
-    }
+        for (Gosu::Image& img : gosu_images) {
+            function(data, new Gosu_Image{img});
+        }
+    });
 }
 
 GOSU_FFI_API void Gosu_Image_create_tiles_from_image(Gosu_Image* image, int tile_width,
@@ -81,29 +93,37 @@ GOSU_FFI_API void Gosu_Image_create_tiles_from_image(Gosu_Image* image, int tile
                                                      void function(void*, Gosu_Image*), void* data,
                                                      unsigned image_flags)
 {
-    std::vector<Gosu::Image> gosu_images =
+    Gosu_translate_exceptions([=] {
+        std::vector<Gosu::Image> gosu_images =
             Gosu::load_tiles(image->image.data().to_bitmap(), tile_width, tile_height, image_flags);
 
-    for (Gosu::Image& img : gosu_images) {
-        function(data, new Gosu_Image{img});
-    }
+        for (Gosu::Image& img : gosu_images) {
+            function(data, new Gosu_Image{img});
+        }
+    });
 }
 
 GOSU_FFI_API void Gosu_Image_destroy(Gosu_Image* image)
 {
-    delete image;
+    Gosu_translate_exceptions([=] {
+        delete image;
+    });
 }
 
 // Properties
 
 GOSU_FFI_API unsigned Gosu_Image_width(Gosu_Image* image)
 {
-    return image->image.width();
+    return Gosu_translate_exceptions([=] {
+        return image->image.width();
+    });
 }
 
 GOSU_FFI_API unsigned Gosu_Image_height(Gosu_Image* image)
 {
-    return image->image.height();
+    return Gosu_translate_exceptions([=] {
+        return image->image.height();
+    });
 }
 
 GOSU_FFI_API Gosu_GLTexInfo* Gosu_Image_gl_tex_info_create(Gosu_Image* image)
@@ -113,13 +133,18 @@ GOSU_FFI_API Gosu_GLTexInfo* Gosu_Image_gl_tex_info_create(Gosu_Image* image)
     static_assert(std::is_trivial_v<Gosu::GLTexInfo>);
     static_assert(std::is_trivial_v<Gosu_GLTexInfo>);
 
-    Gosu::GLTexInfo* gosu_texture_info = new Gosu::GLTexInfo{*image->image.data().gl_tex_info()};
-    return reinterpret_cast<Gosu_GLTexInfo*>(gosu_texture_info);
+    return Gosu_translate_exceptions([=] {
+        Gosu::GLTexInfo* gosu_texture_info =
+            new Gosu::GLTexInfo{*image->image.data().gl_tex_info()};
+        return reinterpret_cast<Gosu_GLTexInfo*>(gosu_texture_info);
+    });
 }
 
 GOSU_FFI_API void Gosu_Image_gl_tex_info_destroy(Gosu_GLTexInfo* gl_tex_info)
 {
-    delete reinterpret_cast<Gosu::GLTexInfo*>(gl_tex_info);
+    Gosu_translate_exceptions([=] {
+        delete reinterpret_cast<Gosu::GLTexInfo*>(gl_tex_info);
+    });
 }
 
 // Rendering
@@ -127,15 +152,19 @@ GOSU_FFI_API void Gosu_Image_gl_tex_info_destroy(Gosu_GLTexInfo* gl_tex_info)
 GOSU_FFI_API void Gosu_Image_draw(Gosu_Image* image, double x, double y, double z, double scale_x,
                                   double scale_y, unsigned color, unsigned mode)
 {
-    image->image.draw(x, y, z, scale_x, scale_y, color, static_cast<Gosu::BlendMode>(mode));
+    Gosu_translate_exceptions([=] {
+        image->image.draw(x, y, z, scale_x, scale_y, color, static_cast<Gosu::BlendMode>(mode));
+    });
 }
 
 GOSU_FFI_API void Gosu_Image_draw_rot(Gosu_Image* image, double x, double y, double z, double angle,
                                       double center_x, double center_y, double scale_x,
                                       double scale_y, unsigned color, unsigned mode)
 {
-    image->image.draw_rot(x, y, z, angle, center_x, center_y, scale_x, scale_y, color,
-                          static_cast<Gosu::BlendMode>(mode));
+    Gosu_translate_exceptions([=] {
+        image->image.draw_rot(x, y, z, angle, center_x, center_y, scale_x, scale_y, color,
+                              static_cast<Gosu::BlendMode>(mode));
+    });
 }
 
 GOSU_FFI_API void Gosu_Image_draw_as_quad(Gosu_Image* image, double x1, double y1, unsigned color1,
@@ -143,26 +172,34 @@ GOSU_FFI_API void Gosu_Image_draw_as_quad(Gosu_Image* image, double x1, double y
                                           double y3, unsigned color3, double x4, double y4,
                                           unsigned color4, double z, unsigned mode)
 {
-    image->image.data().draw(x1, y1, color1, x2, y2, color2, x3, y3, color3, x4, y4, color4, z,
-                             static_cast<Gosu::BlendMode>(mode));
+    Gosu_translate_exceptions([=] {
+        image->image.data().draw(x1, y1, color1, x2, y2, color2, x3, y3, color3, x4, y4, color4, z,
+                                 static_cast<Gosu::BlendMode>(mode));
+    });
 }
 
 // Image operations
 
 GOSU_FFI_API void Gosu_Image_insert(Gosu_Image* image, Gosu_Image* source, int x, int y)
 {
-    Gosu::Bitmap bmp = source->image.data().to_bitmap();
-    image->image.data().insert(bmp, x, y);
+    Gosu_translate_exceptions([=] {
+        Gosu::Bitmap bitmap = source->image.data().to_bitmap();
+        image->image.data().insert(bitmap, x, y);
+    });
 }
 
 GOSU_FFI_API uint8_t* Gosu_Image_to_blob(Gosu_Image* image)
 {
     static thread_local Gosu::Bitmap bitmap;
-    bitmap = image->image.data().to_bitmap();
-    return reinterpret_cast<uint8_t*>(bitmap.data());
+    return Gosu_translate_exceptions([=] {
+        bitmap = image->image.data().to_bitmap();
+        return reinterpret_cast<uint8_t*>(bitmap.data());
+    });
 }
 
 GOSU_FFI_API void Gosu_Image_save(Gosu_Image* image, const char* filename)
 {
-    Gosu::save_image_file(image->image.data().to_bitmap(), filename);
+    Gosu_translate_exceptions([=] {
+        Gosu::save_image_file(image->image.data().to_bitmap(), filename);
+    });
 }

--- a/ffi/Gosu_Sample.cpp
+++ b/ffi/Gosu_Sample.cpp
@@ -2,22 +2,30 @@
 
 GOSU_FFI_API Gosu_Sample* Gosu_Sample_create(const char* filename)
 {
-    return new Gosu_Sample{Gosu::Sample{filename}};
+    return Gosu_translate_exceptions([=] {
+        return new Gosu_Sample{Gosu::Sample{filename}};
+    });
 }
 
 GOSU_FFI_API void Gosu_Sample_destroy(Gosu_Sample* sample)
 {
-    delete sample;
+    Gosu_translate_exceptions([=] {
+        delete sample;
+    });
 }
 
 GOSU_FFI_API Gosu_Channel* Gosu_Sample_play(Gosu_Sample* sample, double volume, double speed,
                                             bool looping)
 {
-    return new Gosu_Channel{sample->sample.play(volume, speed, looping)};
+    return Gosu_translate_exceptions([=] {
+        return new Gosu_Channel{sample->sample.play(volume, speed, looping)};
+    });
 }
 
 GOSU_FFI_API Gosu_Channel* Gosu_Sample_play_pan(Gosu_Sample* sample, double pan, double volume,
                                                 double speed, bool looping)
 {
-    return new Gosu_Channel{sample->sample.play_pan(pan, volume, speed, looping)};
+    return Gosu_translate_exceptions([=] {
+        return new Gosu_Channel{sample->sample.play_pan(pan, volume, speed, looping)};
+    });
 }

--- a/ffi/Gosu_Song.cpp
+++ b/ffi/Gosu_Song.cpp
@@ -2,50 +2,70 @@
 
 GOSU_FFI_API Gosu_Song* Gosu_Song_create(const char* filename)
 {
-    return new Gosu_Song{filename};
+    return Gosu_translate_exceptions([=] {
+        return new Gosu_Song{filename};
+    });
 }
 
 GOSU_FFI_API void Gosu_Song_destroy(Gosu_Song* song)
 {
-    delete song;
+    Gosu_translate_exceptions([=] {
+        delete song;
+    });
 }
 
 GOSU_FFI_API void Gosu_Song_play(Gosu_Song* song, bool looping)
 {
-    song->play(looping);
+    Gosu_translate_exceptions([=] {
+        song->play(looping);
+    });
 }
 
 GOSU_FFI_API bool Gosu_Song_playing(Gosu_Song* song)
 {
-    return song->playing();
+    return Gosu_translate_exceptions([=] {
+        return song->playing();
+    });
 }
 
 GOSU_FFI_API void Gosu_Song_pause(Gosu_Song* song)
 {
-    song->pause();
+    Gosu_translate_exceptions([=] {
+        song->pause();
+    });
 }
 
 GOSU_FFI_API bool Gosu_Song_paused(Gosu_Song* song)
 {
-    return song->paused();
+    return Gosu_translate_exceptions([=] {
+        return song->paused();
+    });
 }
 
 GOSU_FFI_API void Gosu_Song_stop(Gosu_Song* song)
 {
-    song->stop();
+    Gosu_translate_exceptions([=] {
+        song->stop();
+    });
 }
 
 GOSU_FFI_API double Gosu_Song_volume(Gosu_Song* song)
 {
-    return song->volume();
+    return Gosu_translate_exceptions([=] {
+        return song->volume();
+    });
 }
 
 GOSU_FFI_API void Gosu_Song_set_volume(Gosu_Song* song, double volume)
 {
-    return song->set_volume(volume);
+    Gosu_translate_exceptions([=] {
+        return song->set_volume(volume);
+    });
 }
 
 GOSU_FFI_API Gosu_Song* Gosu_Song_current_song(void)
 {
-    return reinterpret_cast<Gosu_Song*>(Gosu::Song::current_song());
+    return Gosu_translate_exceptions([=] {
+        return reinterpret_cast<Gosu_Song*>(Gosu::Song::current_song());
+    });
 }

--- a/ffi/Gosu_TextInput.cpp
+++ b/ffi/Gosu_TextInput.cpp
@@ -2,68 +2,95 @@
 
 GOSU_FFI_API Gosu_TextInput* Gosu_TextInput_create()
 {
-    return new Gosu_TextInput{};
+    return Gosu_translate_exceptions([=] {
+        return new Gosu_TextInput{};
+    });
 }
 
 GOSU_FFI_API void Gosu_TextInput_destroy(Gosu_TextInput* text_input)
 {
-    delete text_input;
+    Gosu_translate_exceptions([=] {
+        delete text_input;
+    });
 }
 
 GOSU_FFI_API const char* Gosu_TextInput_text(Gosu_TextInput* text_input)
 {
     static thread_local std::string text;
-    text = text_input->text();
-    return text.c_str();
+
+    return Gosu_translate_exceptions([=] {
+        text = text_input->text();
+        return text.c_str();
+    });
 }
 
 GOSU_FFI_API void Gosu_TextInput_set_text(Gosu_TextInput* text_input, const char* text)
 {
-    text_input->set_text(text);
+    Gosu_translate_exceptions([=] {
+        text_input->set_text(text);
+    });
 }
 
 GOSU_FFI_API int Gosu_TextInput_caret_pos(Gosu_TextInput* text_input)
 {
-    return text_input->caret_pos();
+    return Gosu_translate_exceptions([=] {
+        return text_input->caret_pos();
+    });
 }
 
 GOSU_FFI_API void Gosu_TextInput_set_caret_pos(Gosu_TextInput* text_input, int pos)
 {
-    text_input->set_caret_pos(pos);
+    Gosu_translate_exceptions([=] {
+        text_input->set_caret_pos(pos);
+    });
 }
 
 GOSU_FFI_API int Gosu_TextInput_selection_start(Gosu_TextInput* text_input)
 {
-    return text_input->selection_start();
+    return Gosu_translate_exceptions([=] {
+        return text_input->selection_start();
+    });
 }
 
 GOSU_FFI_API void Gosu_TextInput_set_selection_start(Gosu_TextInput* text_input, int pos)
 {
-    return text_input->set_selection_start(pos);
+    Gosu_translate_exceptions([=] {
+        text_input->set_selection_start(pos);
+    });
 }
 
 GOSU_FFI_API void Gosu_TextInput_set_filter(Gosu_TextInput* text_input,
                                             void function(void*, const char*), void* data)
 {
-    text_input->filter_callback = [=](const char* text) { function(data, text); };
+    Gosu_translate_exceptions([=] {
+        text_input->filter_callback = [=](const char* text) { function(data, text); };
+    });
 }
 
 GOSU_FFI_API void Gosu_TextInput_set_filter_result(Gosu_TextInput* text_input, const char* result)
 {
-    text_input->filter_result = result;
+    Gosu_translate_exceptions([=] {
+        text_input->filter_result = result;
+    });
 }
 
 GOSU_FFI_API void Gosu_TextInput_insert_text(Gosu_TextInput* text_input, const char* text)
 {
-    text_input->insert_text(text);
+    Gosu_translate_exceptions([=] {
+        text_input->insert_text(text);
+    });
 }
 
 GOSU_FFI_API void Gosu_TextInput_delete_backward(Gosu_TextInput* text_input)
 {
-    text_input->delete_backward();
+    Gosu_translate_exceptions([=] {
+        text_input->delete_backward();
+    });
 }
 
 GOSU_FFI_API void Gosu_TextInput_delete_forward(Gosu_TextInput* text_input)
 {
-    text_input->delete_forward();
+    Gosu_translate_exceptions([=] {
+        text_input->delete_forward();
+    });
 }

--- a/ffi/Gosu_Window.cpp
+++ b/ffi/Gosu_Window.cpp
@@ -5,202 +5,277 @@
 GOSU_FFI_API Gosu_Window* Gosu_Window_create(int width, int height, unsigned window_flags,
                                              double update_interval)
 {
-    return new Gosu_Window{width, height, window_flags, update_interval};
+    return Gosu_translate_exceptions([=] {
+        return new Gosu_Window{width, height, window_flags, update_interval};
+    });
 };
 
 GOSU_FFI_API void Gosu_Window_destroy(Gosu_Window* window)
 {
-    delete window;
+    Gosu_translate_exceptions([=] {
+        delete window;
+    });
 }
 
 // Callbacks
 
 GOSU_FFI_API void Gosu_Window_set_update(Gosu_Window* window, void function(void*), void* data)
 {
-    window->update_callback = [=] { function(data); };
+    Gosu_translate_exceptions([=] {
+        window->update_callback = [=] { function(data); };
+    });
 }
 
 GOSU_FFI_API void Gosu_Window_set_draw(Gosu_Window* window, void function(void*), void* data)
 {
-    window->draw_callback = [=] { function(data); };
+    Gosu_translate_exceptions([=] {
+        window->draw_callback = [=] { function(data); };
+    });
 }
 
 GOSU_FFI_API void Gosu_Window_set_button_down(Gosu_Window* window, void function(void*, unsigned),
                                               void* data)
 {
-    window->button_down_callback = [=](unsigned btn) { function(data, btn); };
+    Gosu_translate_exceptions([=] {
+        window->button_down_callback = [=](unsigned btn) { function(data, btn); };
+    });
 }
 
 GOSU_FFI_API void Gosu_Window_set_button_up(Gosu_Window* window, void function(void*, unsigned),
                                             void* data)
 {
-    window->button_up_callback = [=](unsigned btn) { function(data, btn); };
+    Gosu_translate_exceptions([=] {
+        window->button_up_callback = [=](unsigned btn) { function(data, btn); };
+    });
 }
 
 GOSU_FFI_API void Gosu_Window_set_gamepad_connected(Gosu_Window* window, void function(void*, int),
                                                     void* data)
 {
-    window->gamepad_connected_callback = [=](int id) { function(data, id); };
+    Gosu_translate_exceptions([=] {
+        window->gamepad_connected_callback = [=](int id) { function(data, id); };
+    });
 }
 
 GOSU_FFI_API void Gosu_Window_set_gamepad_disconnected(Gosu_Window* window,
                                                        void function(void*, int), void* data)
 {
-    window->gamepad_disconnected_callback = [=](int id) { function(data, id); };
+    Gosu_translate_exceptions([=] {
+        window->gamepad_disconnected_callback = [=](int id) { function(data, id); };
+    });
 }
 
 GOSU_FFI_API void Gosu_Window_set_drop(Gosu_Window* window, void function(void*, const char*),
                                        void* data)
 {
-    window->drop_callback = [=](const char* filename) { function(data, filename); };
+    Gosu_translate_exceptions([=] {
+        window->drop_callback = [=](const char* filename) { function(data, filename); };
+    });
 }
 
 GOSU_FFI_API void Gosu_Window_set_needs_redraw(Gosu_Window* window, bool function(void*),
                                                void* data)
 {
-    window->needs_redraw_callback = [=] { return function(data); };
+    Gosu_translate_exceptions([=] {
+        window->needs_redraw_callback = [=] { return function(data); };
+    });
 }
 
 GOSU_FFI_API void Gosu_Window_set_needs_cursor(Gosu_Window* window, bool function(void*),
                                                void* data)
 {
-    window->needs_cursor_callback = [=] { return function(data); };
+    Gosu_translate_exceptions([=] {
+        window->needs_cursor_callback = [=] { return function(data); };
+    });
 }
 
 GOSU_FFI_API void Gosu_Window_set_close(Gosu_Window* window, void function(void*), void* data)
 {
-    window->close_callback = [=] { function(data); };
+    Gosu_translate_exceptions([=] {
+        window->close_callback = [=] { function(data); };
+    });
 }
 
 GOSU_FFI_API void Gosu_Window_default_button_down(Gosu_Window* window, unsigned id)
 {
-    window->Gosu::Window::button_down(static_cast<Gosu::Button>(id));
+    Gosu_translate_exceptions([=] {
+        window->Gosu::Window::button_down(static_cast<Gosu::Button>(id));
+    });
 }
 
 // Properties
 
 GOSU_FFI_API int Gosu_Window_width(Gosu_Window* window)
 {
-    return window->width();
+    return Gosu_translate_exceptions([=] {
+        return window->width();
+    });
 }
 
 GOSU_FFI_API void Gosu_Window_set_width(Gosu_Window* window, int width)
 {
-    window->resize(width, window->height(), window->fullscreen());
+    Gosu_translate_exceptions([=] {
+        window->resize(width, window->height(), window->fullscreen());
+    });
 }
 
 GOSU_FFI_API int Gosu_Window_height(Gosu_Window* window)
 {
-    return window->height();
+    return Gosu_translate_exceptions([=] {
+        return window->height();
+    });
 }
 
 GOSU_FFI_API void Gosu_Window_set_height(Gosu_Window* window, int height)
 {
-    window->resize(window->width(), height, window->fullscreen());
+    Gosu_translate_exceptions([=] {
+        window->resize(window->width(), height, window->fullscreen());
+    });
 }
 
 GOSU_FFI_API bool Gosu_Window_is_fullscreen(Gosu_Window* window)
 {
-    return window->fullscreen();
+    return Gosu_translate_exceptions([=] {
+        return window->fullscreen();
+    });
 }
 
 GOSU_FFI_API void Gosu_Window_set_fullscreen(Gosu_Window* window, bool fullscreen)
 {
-    window->resize(window->width(), window->height(), fullscreen);
+    Gosu_translate_exceptions([=] {
+        window->resize(window->width(), window->height(), fullscreen);
+    });
 }
 
 GOSU_FFI_API void Gosu_Window_resize(Gosu_Window* window, int width, int height, bool fullscreen)
 {
-    window->resize(width, height, fullscreen);
+    Gosu_translate_exceptions([=] {
+        window->resize(width, height, fullscreen);
+    });
 }
 
 GOSU_FFI_API bool Gosu_Window_is_resizable(Gosu_Window* window)
 {
-    return window->resizable();
+    return Gosu_translate_exceptions([=] {
+        return window->resizable();
+    });
 }
 
 GOSU_FFI_API void Gosu_Window_set_resizable(Gosu_Window* window, bool resizable)
 {
-    window->set_resizable(resizable);
+    Gosu_translate_exceptions([=] {
+        window->set_resizable(resizable);
+    });
 }
 
 GOSU_FFI_API bool Gosu_Window_is_borderless(Gosu_Window* window)
 {
-    return window->borderless();
+    return Gosu_translate_exceptions([=] {
+        return window->borderless();
+    });
 }
 
 GOSU_FFI_API void Gosu_Window_set_borderless(Gosu_Window* window, bool borderless)
 {
-    window->set_borderless(borderless);
+    Gosu_translate_exceptions([=] {
+        window->set_borderless(borderless);
+    });
 }
 
 GOSU_FFI_API double Gosu_Window_update_interval(Gosu_Window* window)
 {
-    return window->update_interval();
+    return Gosu_translate_exceptions([=] {
+        return window->update_interval();
+    });
 }
 
 GOSU_FFI_API void Gosu_Window_set_update_interval(Gosu_Window* window, double update_interval)
 {
-    window->set_update_interval(update_interval);
+    Gosu_translate_exceptions([=] {
+        window->set_update_interval(update_interval);
+    });
 }
 
 GOSU_FFI_API const char* Gosu_Window_caption(Gosu_Window* window)
 {
     static thread_local std::string caption;
-    caption = window->caption();
-    return caption.c_str();
+
+    return Gosu_translate_exceptions([=] {
+        caption = window->caption();
+        return caption.c_str();
+    });
 }
 
 GOSU_FFI_API void Gosu_Window_set_caption(Gosu_Window* window, const char* caption)
 {
-    window->set_caption(caption);
+    Gosu_translate_exceptions([=] {
+        window->set_caption(caption);
+    });
 }
 
 // Input Properties
 
 GOSU_FFI_API Gosu_TextInput* Gosu_Window_text_input(Gosu_Window* window)
 {
-    return dynamic_cast<Gosu_TextInput*>(window->input().text_input());
+    return Gosu_translate_exceptions([=] {
+        return dynamic_cast<Gosu_TextInput*>(window->input().text_input());
+    });
 }
 
 GOSU_FFI_API void Gosu_Window_set_text_input(Gosu_Window* window, Gosu_TextInput* text_input)
 {
-    window->input().set_text_input(text_input);
+    Gosu_translate_exceptions([=] {
+        window->input().set_text_input(text_input);
+    });
 }
 
 GOSU_FFI_API double Gosu_Window_mouse_x(Gosu_Window* window)
 {
-    return window->input().mouse_x();
+    return Gosu_translate_exceptions([=] {
+        return window->input().mouse_x();
+    });
 }
 
 GOSU_FFI_API void Gosu_Window_set_mouse_x(Gosu_Window* window, double x)
 {
-    window->input().set_mouse_position(x, window->input().mouse_x());
+    Gosu_translate_exceptions([=] {
+        window->input().set_mouse_position(x, window->input().mouse_x());
+    });
 }
 
 GOSU_FFI_API double Gosu_Window_mouse_y(Gosu_Window* window)
 {
-    return window->input().mouse_y();
+    return Gosu_translate_exceptions([=] {
+        return window->input().mouse_y();
+    });
 }
 
 GOSU_FFI_API void Gosu_Window_set_mouse_y(Gosu_Window* window, double y)
 {
-    window->input().set_mouse_position(window->input().mouse_x(), y);
+    Gosu_translate_exceptions([=] {
+        window->input().set_mouse_position(window->input().mouse_x(), y);
+    });
 }
 
 // Main Loop
 
 GOSU_FFI_API void Gosu_Window_show(Gosu_Window* window)
 {
-    window->show();
+    Gosu_translate_exceptions([=] {
+        window->show();
+    });
 }
 
 GOSU_FFI_API bool Gosu_Window_tick(Gosu_Window* window)
 {
-    return window->tick();
+    return Gosu_translate_exceptions([=] {
+        return window->tick();
+    });
 }
 
 GOSU_FFI_API void Gosu_Window_close_immediately(Gosu_Window* window)
 {
-    window->Gosu::Window::close();
+    Gosu_translate_exceptions([=] {
+        window->Gosu::Window::close();
+    });
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,7 @@ if(GTest_FOUND)
 
     file(GLOB TEST_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
     add_executable(GosuTests ${TEST_FILES})
-    target_link_libraries(GosuTests Gosu::Gosu GTest::gtest GTest::gtest_main)
+    target_link_libraries(GosuTests Gosu::Gosu gosu-ffi GTest::gtest GTest::gtest_main)
 
     # Run the tests from within the test/ subdirectory so that we can load
     # media files using relative paths.

--- a/test/FFITests.cpp
+++ b/test/FFITests.cpp
@@ -1,0 +1,32 @@
+#include <Gosu/Utility.hpp>
+#include "../ffi/Gosu.h"
+#include <gtest/gtest.h>
+
+namespace Gosu
+{
+    class FFITests : public testing::Test
+    {
+    };
+
+    TEST_F(FFITests, UserLanguages)
+    {
+        std::vector<std::string> ffi_languages;
+
+        Gosu_get_user_languages([](void* context, const char* language) {
+            static_cast<decltype(ffi_languages)*>(context)->emplace_back(language);
+        }, &ffi_languages);
+
+        ASSERT_EQ(ffi_languages, Gosu::user_languages());
+        ASSERT_EQ(nullptr, Gosu_last_error());
+    }
+
+    TEST_F(FFITests, ImageNotFoundError)
+    {
+        Gosu_Image* image = Gosu_Image_create("/does/not/exist", 0);
+        ASSERT_EQ(nullptr, image);
+        ASSERT_NE(nullptr, Gosu_last_error());
+        // Confirm that the error message is helpful and contains the path that could not be opened.
+        const std::string error_message = Gosu_last_error();
+        ASSERT_NE(std::string::npos, error_message.find("/does/not/exist"));
+    }
+}


### PR DESCRIPTION
Rationale:
* For parity with SWIG Ruby/Gosu, ffi-gosu and gosu.cr need to throw helpful error messages when something goes wrong.
* The global Gosu_last_error() function should be easier to wrap than additional out parameters.
* For consistency, all Gosu_ functions (re)set the error, even ones like Gosu_milliseconds() which will hopefully never throw an exception.
  * ...except Color functions. Too weird?
* There is only an error message right now. Adding a Gosu_last_error_type() function later should be easy, but Gosu itself does not really throw many interesting exception classes, mostly runtime_error and invalid_argument.

Downsides:
* Now even harmless functions like Gosu_milliseconds should technically be wrapped in Ruby for error processing :( ... but otherwise, this is going to be a mess to document.