### PR TITLE
User languages patches

### DIFF
--- a/ffi/Gosu.cpp
+++ b/ffi/Gosu.cpp
@@ -181,7 +181,7 @@ GOSU_FFI_API int Gosu_fps()
     return Gosu::fps();
 }
 
-GOSU_FFI_API void Gosu_get_user_languages(void function(void*, const char*), void* data)
+GOSU_FFI_API void Gosu_user_languages(void function(void*, const char*), void* data)
 {
     for (const std::string& user_language : Gosu::user_languages()) {
         function(data, user_language.c_str());

--- a/ffi/Gosu.h
+++ b/ffi/Gosu.h
@@ -71,7 +71,7 @@ GOSU_FFI_API double Gosu_axis(int id);
 
 // Misc
 GOSU_FFI_API int Gosu_fps(void);
-GOSU_FFI_API void Gosu_get_user_languages(void function(void* data, const char* language),
-                                          void* data);
+GOSU_FFI_API void Gosu_user_languages(void function(void* data, const char* language),
+                                      void* data);
 GOSU_FFI_API uint64_t Gosu_milliseconds(void);
 GOSU_FFI_API const char* Gosu_default_font_name(void);


### PR DESCRIPTION
* Drop `_get_` from `Gosu_get_user_languages` FFI function (@jlnr Is `_get_` intended?)
* Fix possible crash if `Gosu.user_languages` returns nil by using Ruby's safe navigation operator