### PR TITLE
Add Gosu::Video

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,16 @@ find_package(SDL2 REQUIRED)
 find_package(OpenAL REQUIRED)
 find_package(OpenGL REQUIRED)
 
+if(ENABLE_FFMPEG)
+    add_compile_definitions(ENABLE_FFMPEG)
+
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(libavcodec REQUIRED libavcodec)
+    pkg_check_modules(libavformat REQUIRED libavformat)
+    set(FFMPEG_LIBRARIES avcodec avformat)
+    set(FFMPEG_INCLUDE_DIRS /usr/include)
+endif()
+
 if(APPLE)
     find_library(COCOA_LIBRARY Cocoa)
     find_library(AUDIO_TOOLBOX_LIBRARY AudioToolbox)
@@ -65,7 +75,8 @@ target_include_directories(gosu
         ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/stb
         ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/utf8proc
         ${SDL2_INCLUDE_DIRS}
-        ${OPENAL_INCLUDE_DIRS})
+        ${OPENAL_INCLUDE_DIRS}
+        ${FFMPEG_INCLUDE_DIRS})
 
 target_link_libraries(gosu
     PRIVATE
@@ -73,6 +84,7 @@ target_link_libraries(gosu
         ${SDL2_LIBRARIES}
         OpenGL::GL
         ${OPENAL_LIBRARY}
+        ${FFMPEG_LIBRARIES}
         # Only defined on macOS
         ${COCOA_LIBRARY}
         ${AUDIO_TOOLBOX_LIBRARY}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,14 +23,13 @@ find_package(SDL2 REQUIRED)
 find_package(OpenAL REQUIRED)
 find_package(OpenGL REQUIRED)
 
-if(ENABLE_FFMPEG)
-    add_compile_definitions(ENABLE_FFMPEG)
+if(GOSU_ENABLE_VIDEO)
+    add_compile_definitions(GOSU_ENABLE_VIDEO)
 
     find_package(PkgConfig REQUIRED)
-    pkg_check_modules(libavcodec REQUIRED libavcodec)
-    pkg_check_modules(libavformat REQUIRED libavformat)
-    set(FFMPEG_LIBRARIES avcodec avformat)
-    set(FFMPEG_INCLUDE_DIRS /usr/include)
+    pkg_check_modules(libvlc REQUIRED libvlc)
+    set(VLC_LIBRARY vlc)
+    set(VLC_INCLUDE_DIRS /usr/include)
 endif()
 
 if(APPLE)
@@ -76,7 +75,7 @@ target_include_directories(gosu
         ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/utf8proc
         ${SDL2_INCLUDE_DIRS}
         ${OPENAL_INCLUDE_DIRS}
-        ${FFMPEG_INCLUDE_DIRS})
+        ${VLC_INCLUDE_DIRS})
 
 target_link_libraries(gosu
     PRIVATE
@@ -84,7 +83,7 @@ target_link_libraries(gosu
         ${SDL2_LIBRARIES}
         OpenGL::GL
         ${OPENAL_LIBRARY}
-        ${FFMPEG_LIBRARIES}
+        ${VLC_LIBRARY}
         # Only defined on macOS
         ${COCOA_LIBRARY}
         ${AUDIO_TOOLBOX_LIBRARY}

--- a/ffi/Gosu.h
+++ b/ffi/Gosu.h
@@ -9,7 +9,7 @@
 #include "Gosu_Song.h"
 #include "Gosu_TextInput.h"
 #include "Gosu_Window.h"
-#ifdef ENABLE_FFMPEG
+#ifdef GOSU_ENABLE_VIDEO
 #include "Gosu_Video.h"
 #endif
 #include <stdint.h>

--- a/ffi/Gosu.h
+++ b/ffi/Gosu.h
@@ -9,6 +9,9 @@
 #include "Gosu_Song.h"
 #include "Gosu_TextInput.h"
 #include "Gosu_Window.h"
+#ifdef ENABLE_FFMPEG
+#include "Gosu_Video.h"
+#endif
 #include <stdint.h>
 
 // Error reporting

--- a/ffi/Gosu_FFI_internal.h
+++ b/ffi/Gosu_FFI_internal.h
@@ -43,6 +43,13 @@ struct Gosu_Image
     Gosu::Image image;
 };
 
+#ifdef ENABLE_FFMPEG
+struct Gosu_Video
+{
+    Gosu::Video video;
+};
+#endif
+
 struct Gosu_Sample
 {
     Gosu::Sample sample;

--- a/ffi/Gosu_FFI_internal.h
+++ b/ffi/Gosu_FFI_internal.h
@@ -43,7 +43,7 @@ struct Gosu_Image
     Gosu::Image image;
 };
 
-#ifdef ENABLE_FFMPEG
+#ifdef GOSU_ENABLE_VIDEO
 struct Gosu_Video
 {
     Gosu::Video video;

--- a/ffi/Gosu_Video.cpp
+++ b/ffi/Gosu_Video.cpp
@@ -1,0 +1,15 @@
+#include "Gosu_FFI_internal.h"
+
+#ifdef ENABLE_FFMPEG
+
+GOSU_FFI_API Gosu_Video* Gosu_Video_create(const char* filename, unsigned image_flags)
+{
+    return Gosu_translate_exceptions([=] { return new Gosu_Video{Gosu::Video(filename, image_flags)}; });
+}
+
+GOSU_FFI_API Gosu_Video* Gosu_Video_create_scaled(const char* filename, int width, int height, unsigned image_flags)
+{
+    return Gosu_translate_exceptions([=] { return new Gosu_Video{Gosu::Video(filename, width, height, image_flags)}; });
+}
+
+#endif

--- a/ffi/Gosu_Video.cpp
+++ b/ffi/Gosu_Video.cpp
@@ -1,15 +1,107 @@
-#include "Gosu_FFI_internal.h"
+#ifdef GOSU_ENABLE_VIDEO
 
-#ifdef ENABLE_FFMPEG
+#include "Gosu_FFI_internal.h"
 
 GOSU_FFI_API Gosu_Video* Gosu_Video_create(const char* filename, unsigned image_flags)
 {
-    return Gosu_translate_exceptions([=] { return new Gosu_Video{Gosu::Video(filename, image_flags)}; });
+    return Gosu_translate_exceptions(
+            [=] { return new Gosu_Video{Gosu::Video(filename, image_flags)}; });
 }
 
-GOSU_FFI_API Gosu_Video* Gosu_Video_create_scaled(const char* filename, int width, int height, unsigned image_flags)
+GOSU_FFI_API Gosu_Video* Gosu_Video_create_scaled(const char* filename, int width, int height,
+                                                  unsigned image_flags)
 {
-    return Gosu_translate_exceptions([=] { return new Gosu_Video{Gosu::Video(filename, width, height, image_flags)}; });
+    return Gosu_translate_exceptions(
+            [=] { return new Gosu_Video{Gosu::Video(filename, width, height, image_flags)}; });
+}
+
+GOSU_FFI_API unsigned Gosu_Video_width(Gosu_Video* video)
+{
+    return Gosu_translate_exceptions([=] { return video->video.width(); });
+}
+
+GOSU_FFI_API unsigned Gosu_Video_height(Gosu_Video* video)
+{
+    return Gosu_translate_exceptions([=] { return video->video.height(); });
+}
+
+GOSU_FFI_API void Gosu_Video_draw(Gosu_Video* video, double x, double y, double z, double scale_x,
+                                  double scale_y, unsigned color, unsigned mode)
+{
+    Gosu_translate_exceptions([=] {
+        video->video.draw(x, y, z, scale_x, scale_y, color, static_cast<Gosu::BlendMode>(mode));
+    });
+}
+
+GOSU_FFI_API void Gosu_Video_draw_rot(Gosu_Video* video, double x, double y, double z, double angle,
+                                      double center_x, double center_y, double scale_x,
+                                      double scale_y, unsigned color, unsigned mode)
+{
+    Gosu_translate_exceptions([=] {
+        video->video.draw_rot(x, y, z, angle, center_x, center_y, scale_x, scale_y, color,
+                              static_cast<Gosu::BlendMode>(mode));
+    });
+}
+
+GOSU_FFI_API void Gosu_Video_draw_as_quad(Gosu_Video* video, double x1, double y1, unsigned color1,
+                                          double x2, double y2, unsigned color2, double x3,
+                                          double y3, unsigned color3, double x4, double y4,
+                                          unsigned color4, double z, unsigned mode)
+{
+    Gosu_translate_exceptions([=] {
+        video->video.draw_as_quad(x1, y1, color1, x2, y2, color2, x3, y3, color3, x4, y4, color4, z,
+                                  static_cast<Gosu::BlendMode>(mode));
+    });
+}
+
+GOSU_FFI_API void Gosu_Video_pause(Gosu_Video* video)
+{
+    Gosu_translate_exceptions([=] { video->video.pause(); });
+}
+
+GOSU_FFI_API bool Gosu_Video_paused(Gosu_Video* video)
+{
+    return Gosu_translate_exceptions([=] { return video->video.paused(); });
+}
+
+GOSU_FFI_API void Gosu_Video_play(Gosu_Video* video, bool looping)
+{
+    Gosu_translate_exceptions([=] { video->video.play(looping); });
+}
+
+GOSU_FFI_API bool Gosu_Video_playing(Gosu_Video* video)
+{
+    return Gosu_translate_exceptions([=] { return video->video.playing(); });
+}
+
+GOSU_FFI_API void Gosu_Video_stop(Gosu_Video* video)
+{
+    Gosu_translate_exceptions([=] { video->video.stop(); });
+}
+
+GOSU_FFI_API double Gosu_Video_volume(Gosu_Video* video)
+{
+    return Gosu_translate_exceptions([=] { return video->video.volume(); });
+}
+
+GOSU_FFI_API void Gosu_Video_set_volume(Gosu_Video* video, double volume)
+{
+    Gosu_translate_exceptions([=] { video->video.set_volume(volume); });
+}
+
+GOSU_FFI_API double Gosu_Video_length(Gosu_Video* video)
+{
+    return Gosu_translate_exceptions([=] { return video->video.length(); });
+}
+
+GOSU_FFI_API double Gosu_Video_position(Gosu_Video* video)
+{
+    return Gosu_translate_exceptions([=] { return video->video.position(); });
+}
+
+GOSU_FFI_API void Gosu_Video_set_position(Gosu_Video* video, double position)
+{
+    Gosu_translate_exceptions([=] { video->video.set_position(position); });
 }
 
 #endif

--- a/ffi/Gosu_Video.h
+++ b/ffi/Gosu_Video.h
@@ -1,4 +1,4 @@
-#ifdef ENABLE_FFMPEG
+#ifdef GOSU_ENABLE_VIDEO
 
 #pragma once
 
@@ -10,6 +10,19 @@ GOSU_FFI_API Gosu_Video* Gosu_Video_create(const char* filename, unsigned image_
 GOSU_FFI_API Gosu_Video* Gosu_Video_create_scaled(const char* filename, int width, int height, unsigned image_flags);
 GOSU_FFI_API void Gosu_Video_destroy(Gosu_Video* video);
 
+GOSU_FFI_API unsigned Gosu_Video_width(Gosu_Video* video);
+GOSU_FFI_API unsigned Gosu_Video_height(Gosu_Video* video);
+
+GOSU_FFI_API void Gosu_Video_draw(Gosu_Video* video, double x, double y, double z, double scale_x,
+                                  double scale_y, unsigned color, unsigned mode);
+GOSU_FFI_API void Gosu_Video_draw_rot(Gosu_Video* video, double x, double y, double z, double angle,
+                                      double center_x, double center_y, double scale_x,
+                                      double scale_y, unsigned color, unsigned mode);
+GOSU_FFI_API void Gosu_Video_draw_as_quad(Gosu_Video* video, double x1, double y1, unsigned color1,
+                                          double x2, double y2, unsigned color2, double x3,
+                                          double y3, unsigned color3, double x4, double y4,
+                                          unsigned color4, double z, unsigned mode);
+
 GOSU_FFI_API void Gosu_Video_pause(Gosu_Video* video);
 GOSU_FFI_API bool Gosu_Video_paused(Gosu_Video* video);
 GOSU_FFI_API void Gosu_Video_play(Gosu_Video* video, bool looping);
@@ -17,5 +30,8 @@ GOSU_FFI_API bool Gosu_Video_playing(Gosu_Video* video);
 GOSU_FFI_API void Gosu_Video_stop(Gosu_Video* video);
 GOSU_FFI_API double Gosu_Video_volume(Gosu_Video* video);
 GOSU_FFI_API void Gosu_Video_set_volume(Gosu_Video* video, double volume);
+GOSU_FFI_API double Gosu_Video_length(Gosu_Video* video);
+GOSU_FFI_API double Gosu_Video_position(Gosu_Video* video);
+GOSU_FFI_API void Gosu_Video_set_position(Gosu_Video* video, double position);
 
 #endif

--- a/ffi/Gosu_Video.h
+++ b/ffi/Gosu_Video.h
@@ -1,0 +1,21 @@
+#ifdef ENABLE_FFMPEG
+
+#pragma once
+
+#include "Gosu_FFI.h"
+
+typedef struct Gosu_Video Gosu_Video;
+
+GOSU_FFI_API Gosu_Video* Gosu_Video_create(const char* filename, unsigned image_flags);
+GOSU_FFI_API Gosu_Video* Gosu_Video_create_scaled(const char* filename, int width, int height, unsigned image_flags);
+GOSU_FFI_API void Gosu_Video_destroy(Gosu_Video* video);
+
+GOSU_FFI_API void Gosu_Video_pause(Gosu_Video* video);
+GOSU_FFI_API bool Gosu_Video_paused(Gosu_Video* video);
+GOSU_FFI_API void Gosu_Video_play(Gosu_Video* video, bool looping);
+GOSU_FFI_API bool Gosu_Video_playing(Gosu_Video* video);
+GOSU_FFI_API void Gosu_Video_stop(Gosu_Video* video);
+GOSU_FFI_API double Gosu_Video_volume(Gosu_Video* video);
+GOSU_FFI_API void Gosu_Video_set_volume(Gosu_Video* video, double volume);
+
+#endif

--- a/include/Gosu/Fwd.hpp
+++ b/include/Gosu/Fwd.hpp
@@ -19,4 +19,5 @@ namespace Gosu
     class TextInput;
     class Window;
     class Writer;
+    class Video;
 }

--- a/include/Gosu/Gosu.hpp
+++ b/include/Gosu/Gosu.hpp
@@ -28,3 +28,6 @@
 #include <Gosu/Utility.hpp>
 #include <Gosu/Version.hpp>
 #include <Gosu/Window.hpp>
+#ifdef ENABLE_FFMPEG
+#include <Gosu/Video.hpp>
+#endif

--- a/include/Gosu/Gosu.hpp
+++ b/include/Gosu/Gosu.hpp
@@ -28,6 +28,6 @@
 #include <Gosu/Utility.hpp>
 #include <Gosu/Version.hpp>
 #include <Gosu/Window.hpp>
-#ifdef ENABLE_FFMPEG
+#ifdef GOSU_ENABLE_VIDEO
 #include <Gosu/Video.hpp>
 #endif

--- a/include/Gosu/Video.hpp
+++ b/include/Gosu/Video.hpp
@@ -1,15 +1,31 @@
-// TODO: Change to #ifdef when done implementing!
-#ifndef USE_FFMPEG
+#ifdef ENABLE_FFMPEG
 
 #pragma once
 
 #include <Gosu/Fwd.hpp>
+#include <Gosu/Graphics.hpp>
+#include <Gosu/GraphicsBase.hpp>
 #include <Gosu/IO.hpp>
+#include <Gosu/Math.hpp>
 #include <Gosu/Platform.hpp>
+#include <Gosu/Utility.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <cstdlib>
 #include <memory>
 #include <string>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+
+#ifdef __cplusplus
+}
+#endif
 
 namespace Gosu
 {

--- a/include/Gosu/Video.hpp
+++ b/include/Gosu/Video.hpp
@@ -1,0 +1,61 @@
+// TODO: Change to #ifdef when done implementing!
+#ifndef USE_FFMPEG
+
+#pragma once
+
+#include <Gosu/Fwd.hpp>
+#include <Gosu/IO.hpp>
+#include <Gosu/Platform.hpp>
+#include <memory>
+#include <string>
+
+#include <libavcodec/avcodec.h>
+
+namespace Gosu
+{
+    class Video
+    {
+        struct Impl;
+        std::shared_ptr<Impl> pimpl;
+
+    public:
+        Video(const std::string& filename, unsigned image_flags);
+        Video(const std::string& filename, double width, double height, unsigned image_flags);
+
+        ~Video();
+
+        unsigned width() const;
+
+        unsigned height() const;
+
+        void draw(double x, double y, ZPos z, double scale_x, double scale_y, Color c,
+                  BlendMode mode) const;
+
+        void draw_rot(double x, double y, ZPos z, double angle, double center_x, double center_y,
+                      double scale_x, double scale_y, Color c, BlendMode mode) const;
+
+        void play(bool looping = false);
+
+        void pause();
+
+        bool paused() const;
+
+        void stop();
+
+        bool playing() const;
+
+        double volume() const;
+
+        void set_volume(double volume);
+
+        double length() const;
+
+        double position() const;
+
+        void set_position(double position);
+
+        void update();
+    };
+};
+
+#endif

--- a/include/Gosu/Video.hpp
+++ b/include/Gosu/Video.hpp
@@ -3,33 +3,12 @@
 #pragma once
 
 #include <Gosu/Bitmap.hpp>
-#include <Gosu/Fwd.hpp>
-#include <Gosu/Graphics.hpp>
-#include <Gosu/GraphicsBase.hpp>
-#include <Gosu/IO.hpp>
 #include <Gosu/Image.hpp>
 #include <Gosu/ImageData.hpp>
 #include <Gosu/Math.hpp>
-#include <Gosu/Platform.hpp>
-#include <Gosu/Utility.hpp>
-#include <Gosu/Window.hpp>
-#include <stdexcept>
 
-#include <algorithm>
 #include <cassert>
-#include <cstdlib>
-#include <memory>
 #include <string>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include <vlc/vlc.h>
-
-#ifdef __cplusplus
-}
-#endif
 
 namespace Gosu
 {
@@ -39,10 +18,14 @@ namespace Gosu
         std::shared_ptr<Impl> pimpl;
 
     public:
+        // Prevent concurrent modification
+        static void lock_all();
+        static void unlock_all();
+
         Video(const std::string& filename, unsigned image_flags);
         Video(const std::string& filename, double width, double height, unsigned image_flags);
 
-        ~Video();
+        virtual ~Video();
 
         unsigned width() const;
 
@@ -79,7 +62,12 @@ namespace Gosu
 
         void update();
 
-        Gosu::Image* image();
+        void lock();
+
+        void unlock();
+
+        // Current video frame as Gosu::Image
+        Gosu::Image image();
     };
 };
 

--- a/include/Gosu/Video.hpp
+++ b/include/Gosu/Video.hpp
@@ -1,14 +1,19 @@
-#ifdef ENABLE_FFMPEG
+#ifdef GOSU_ENABLE_VIDEO
 
 #pragma once
 
+#include <Gosu/Bitmap.hpp>
 #include <Gosu/Fwd.hpp>
 #include <Gosu/Graphics.hpp>
 #include <Gosu/GraphicsBase.hpp>
 #include <Gosu/IO.hpp>
+#include <Gosu/Image.hpp>
+#include <Gosu/ImageData.hpp>
 #include <Gosu/Math.hpp>
 #include <Gosu/Platform.hpp>
 #include <Gosu/Utility.hpp>
+#include <Gosu/Window.hpp>
+#include <stdexcept>
 
 #include <algorithm>
 #include <cassert>
@@ -20,8 +25,7 @@
 extern "C" {
 #endif
 
-#include <libavcodec/avcodec.h>
-#include <libavformat/avformat.h>
+#include <vlc/vlc.h>
 
 #ifdef __cplusplus
 }
@@ -49,6 +53,9 @@ namespace Gosu
 
         void draw_rot(double x, double y, ZPos z, double angle, double center_x, double center_y,
                       double scale_x, double scale_y, Color c, BlendMode mode) const;
+        void draw_as_quad(double x1, double y1, unsigned color1, double x2, double y2,
+                          unsigned color2, double x3, double y3, unsigned color3, double x4,
+                          double y4, unsigned color4, double z, BlendMode mode) const;
 
         void play(bool looping = false);
 
@@ -71,6 +78,8 @@ namespace Gosu
         void set_position(double position);
 
         void update();
+
+        Gosu::Image* image();
     };
 };
 

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -110,7 +110,7 @@ vector<Gosu::Image> Gosu::load_tiles(const Bitmap& bmp, int tile_width, int tile
 {
     int tiles_x, tiles_y;
     vector<Image> images;
-    
+
     if (tile_width > 0) {
         tiles_x = bmp.width() / tile_width;
     }
@@ -118,7 +118,7 @@ vector<Gosu::Image> Gosu::load_tiles(const Bitmap& bmp, int tile_width, int tile
         tiles_x = -tile_width;
         tile_width = bmp.width() / tiles_x;
     }
-    
+
     if (tile_height > 0) {
         tiles_y = bmp.height() / tile_height;
     }
@@ -126,14 +126,14 @@ vector<Gosu::Image> Gosu::load_tiles(const Bitmap& bmp, int tile_width, int tile
         tiles_y = -tile_height;
         tile_height = bmp.height() / tiles_y;
     }
-    
+
     for (int y = 0; y < tiles_y; ++y) {
         for (int x = 0; x < tiles_x; ++x) {
             images.emplace_back(bmp, x * tile_width, y * tile_height, tile_width, tile_height,
                                 flags);
         }
     }
-    
+
     return images;
 }
 

--- a/src/Video.cpp
+++ b/src/Video.cpp
@@ -28,32 +28,27 @@ struct Gosu::Video::Impl
 
     static void* lock_video(void* data, void** p_pixels)
     {
-        puts("REACHED lock_video");
         struct context* ctx = (context*) data;
-        puts("REACHED ctx");
-        ctx->locked = true;
-        puts("REACHED LOCKER");
-        *p_pixels = ctx->bitmap->data();
-        puts("REACHED DATA");
 
-        puts("REACHED LOCK");
-        return NULL;
+        ctx->locked = true;
+        *p_pixels = ctx->bitmap->data();
+
+        return nullptr;
     }
 
     static void unlock_video(void* data, void* picture, void* const* p_pixels)
     {
         struct context* ctx = (context*) data;
         ctx->locked = false;
-        puts("REACHED UNLOCK");
 
-        assert (picture == NULL);
+        assert (picture == nullptr);
     }
 
     static void display(void* data, void* picture)
     {
-        puts("REACHED DISPLAY");
         struct context* ctx = (context*) data;
 
+        // TODO: Optimize this
         ctx->image = new Gosu::Image(*ctx->bitmap);
     }
 
@@ -72,9 +67,8 @@ struct Gosu::Video::Impl
         // Start playing for a few microseconds to get metadata
         libvlc_media_player_play(vlc_media_player_);
 
-        libvlc_state_t vlc_media_player_state_ = libvlc_media_player_get_state(vlc_media_player_);
-
         // Block main thread while VLC buffers media
+        libvlc_state_t vlc_media_player_state_ = libvlc_media_player_get_state(vlc_media_player_);
         while (libvlc_media_player_get_length(vlc_media_player_) <= 0) {
         }
 
@@ -118,6 +112,7 @@ public:
     ~Impl()
     {
         libvlc_media_player_stop(vlc_media_player_);
+        libvlc_media_player_release(vlc_media_player_);
         libvlc_release(vlc_instance_);
     }
 

--- a/src/Video.cpp
+++ b/src/Video.cpp
@@ -1,6 +1,5 @@
 #ifdef GOSU_ENABLE_VIDEO
 
-#include "GraphicsImpl.hpp"
 #include <Gosu/Video.hpp>
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_syswm.h>
@@ -10,15 +9,18 @@ struct Gosu::Video::Impl
     struct context
     {
         bool locked = false;
+        Gosu::Image* image;
         Gosu::Bitmap* bitmap;
     };
 
     double volume_ = 1.0;
     bool looping_ = false;
     double duration_;
-    unsigned video_width_ = 0, video_height_ = 0;
+    unsigned video_width_ = 640, video_height_ = 480;
     unsigned image_width_ = 0, image_height_ = 0;
     unsigned image_flags_ = ImageFlags::IF_SMOOTH;
+
+    struct context ctx_;
 
     libvlc_instance_t *vlc_instance_;
     libvlc_media_t *vlc_media_;
@@ -26,37 +28,44 @@ struct Gosu::Video::Impl
 
     static void* lock_video(void* data, void** p_pixels)
     {
-        struct context* ctx = (context *) data;
-
+        puts("REACHED lock_video");
+        struct context* ctx = (context*) data;
+        puts("REACHED ctx");
         ctx->locked = true;
+        puts("REACHED LOCKER");
         *p_pixels = ctx->bitmap->data();
+        puts("REACHED DATA");
+
+        puts("REACHED LOCK");
         return NULL;
     }
 
-    static void unlock_video(void* data, void* id, void* const* p_pixels)
+    static void unlock_video(void* data, void* picture, void* const* p_pixels)
     {
         struct context* ctx = (context*) data;
+        ctx->locked = false;
+        puts("REACHED UNLOCK");
 
-        assert(id == NULL);
+        assert (picture == NULL);
     }
-    static void display(void* data, void* id)
-    {
 
+    static void display(void* data, void* picture)
+    {
+        puts("REACHED DISPLAY");
+        struct context* ctx = (context*) data;
     }
 
     void apply_volume()
     {
-        // Do stuff
-        // volume();
+        libvlc_audio_set_volume(vlc_media_player_, volume());
     }
 
     void initialize_video(const std::string filename)
     {
-        struct context context;
-
-        vlc_instance_ = libvlc_new(0, NULL);
+        vlc_instance_ = libvlc_new(0, nullptr);
         vlc_media_ = libvlc_media_new_path(vlc_instance_, filename.c_str());
         vlc_media_player_ = libvlc_media_player_new_from_media(vlc_media_);
+        libvlc_media_release(vlc_media_);
 
         // Start playing for a few microseconds to get metadata
         libvlc_media_player_play(vlc_media_player_);
@@ -72,9 +81,15 @@ struct Gosu::Video::Impl
 
         libvlc_media_player_stop(vlc_media_player_);
 
-        // TODO: Resolve segfault use this callback instead of making VLC draw to window
-        // libvlc_video_set_callbacks(vlc_media_player_, lock_video, nullptr, nullptr, nullptr);
-        // libvlc_video_set_format(vlc_media_player_, "RGBA", video_width_, video_height_, video_width_ * 4);
+        ctx_.bitmap = new Bitmap();
+        ctx_.bitmap->resize(width(), height(), Gosu::Color::BLUE);
+        ctx_.image = new Image(*ctx_.bitmap, image_flags_);
+
+        // TODO: Resolve segfault and use this callback instead of making VLC draw to window
+        libvlc_video_set_callbacks(vlc_media_player_, lock_video, unlock_video, display, &ctx_);
+        libvlc_video_set_format(vlc_media_player_, "RGBA", width(), height(), video_width_ * 4);
+        // VLC 4 function for OpenGL: https://github.com/videolan/vlc/blob/master/doc/libvlc/sdl_opengl_player.cpp
+        // libvlc_video_set_output_callbacks(vlc_media_player_);
     }
 
 public:
@@ -116,34 +131,33 @@ public:
 
     Gosu::Image* image()
     {
-        return new Gosu::Image(Bitmap(width(), height(), Gosu::Color::BLUE));
+        return ctx_.image;// new Gosu::Image(Bitmap(width(), height(), Gosu::Color::BLUE));
     }
 
     void play(bool looping)
     {
         looping_ = looping;
-        libvlc_media_player_set_xwindow(vlc_media_player_, SDL_GetWindowID(Gosu::shared_window()));
         libvlc_media_player_play(vlc_media_player_);
     }
 
     void pause()
     {
+        libvlc_media_player_pause(vlc_media_player_);
     }
 
     void stop()
     {
-        libvlc_media_player_set_xwindow(vlc_media_player_, 0);
         libvlc_media_player_stop(vlc_media_player_);
     }
 
     bool playing()
     {
-        return false;
+        return libvlc_media_player_is_playing(vlc_media_player_);
     }
 
     bool paused()
     {
-        return false;
+        return !playing();
     }
 
     double volume() const

--- a/src/Video.cpp
+++ b/src/Video.cpp
@@ -2,15 +2,22 @@
 
 #include <Gosu/Video.hpp>
 #include <SDL2/SDL.h>
-#include <SDL2/SDL_syswm.h>
+#include <mutex>
+#include <vector>
+
+extern "C" {
+#include <vlc/vlc.h>
+}
+
+static std::vector<Gosu::Video*> current_videos;
 
 struct Gosu::Video::Impl
 {
     struct context
     {
-        bool locked = false;
-        Gosu::Image* image;
-        Gosu::Bitmap* bitmap;
+        std::mutex frame_lock, video_lock;
+        Gosu::Image image;
+        Gosu::Bitmap bitmap;
     };
 
     double volume_ = 1.0;
@@ -30,8 +37,8 @@ struct Gosu::Video::Impl
     {
         struct context* ctx = (context*) data;
 
-        ctx->locked = true;
-        *p_pixels = ctx->bitmap->data();
+        ctx->frame_lock.lock();
+        *p_pixels = ctx->bitmap.data();
 
         return nullptr;
     }
@@ -39,7 +46,7 @@ struct Gosu::Video::Impl
     static void unlock_video(void* data, void* picture, void* const* p_pixels)
     {
         struct context* ctx = (context*) data;
-        ctx->locked = false;
+        ctx->frame_lock.unlock();
 
         assert (picture == nullptr);
     }
@@ -47,9 +54,10 @@ struct Gosu::Video::Impl
     static void display(void* data, void* picture)
     {
         struct context* ctx = (context*) data;
-
+        const std::lock_guard<std::mutex> lock(ctx->video_lock);
         // TODO: Optimize this
-        ctx->image = new Gosu::Image(*ctx->bitmap);
+        ctx->image = Gosu::Image(ctx->bitmap);
+        // ctx->image.data().insert(ctx->bitmap, 0, 0);
     }
 
     void apply_volume()
@@ -60,12 +68,27 @@ struct Gosu::Video::Impl
     void initialize_video(const std::string filename)
     {
         vlc_instance_ = libvlc_new(0, nullptr);
+
+        if (!vlc_instance_) {
+            throw std::runtime_error("Failed to create VLC instance");
+        }
+
         vlc_media_ = libvlc_media_new_path(vlc_instance_, filename.c_str());
+
+        if (!vlc_media_) {
+            throw std::runtime_error("Failed to create VLC media");
+        }
+
         vlc_media_player_ = libvlc_media_player_new_from_media(vlc_media_);
+
+        if (!vlc_media_player_) {
+            throw std::runtime_error("Failed to create VLC media player");
+        }
+
         libvlc_media_release(vlc_media_);
 
         // Start playing for a few microseconds to get metadata
-        libvlc_media_player_play(vlc_media_player_);
+        play(false);//libvlc_media_player_play(vlc_media_player_);
 
         // Block main thread while VLC buffers media
         libvlc_state_t vlc_media_player_state_ = libvlc_media_player_get_state(vlc_media_player_);
@@ -75,13 +98,12 @@ struct Gosu::Video::Impl
         duration_ = libvlc_media_player_get_length(vlc_media_player_) / 1000.0;
         libvlc_video_get_size(vlc_media_player_, 0, &video_width_, &video_height_);
 
-        libvlc_media_player_stop(vlc_media_player_);
+        stop();
 
-        ctx_.bitmap = new Bitmap();
-        ctx_.bitmap->resize(width(), height(), Gosu::Color::BLUE);
-        ctx_.image = new Image(*ctx_.bitmap, image_flags_);
+        ctx_.bitmap = Bitmap();
+        ctx_.bitmap.resize(width(), height(), Gosu::Color::GREEN);
+        ctx_.image = Image(ctx_.bitmap, image_flags_);
 
-        // TODO: Resolve segfault and use this callback instead of making VLC draw to window
         libvlc_video_set_callbacks(vlc_media_player_, lock_video, unlock_video, display, &ctx_);
         libvlc_video_set_format(vlc_media_player_, "RGBA", width(), height(), video_width_ * 4);
         // VLC 4 function for OpenGL: https://github.com/videolan/vlc/blob/master/doc/libvlc/sdl_opengl_player.cpp
@@ -111,9 +133,14 @@ public:
     // TODO: clean up
     ~Impl()
     {
-        libvlc_media_player_stop(vlc_media_player_);
-        libvlc_media_player_release(vlc_media_player_);
-        libvlc_release(vlc_instance_);
+        if (vlc_media_player_) {
+            libvlc_media_player_stop(vlc_media_player_);
+            libvlc_media_player_release(vlc_media_player_);
+        }
+
+        if (vlc_instance_) {
+            libvlc_release(vlc_instance_);
+        }
     }
 
     unsigned width()
@@ -126,15 +153,20 @@ public:
         return video_height_;
     }
 
-    Gosu::Image* image()
+    Gosu::Image image()
     {
-        return ctx_.image;// new Gosu::Image(Bitmap(width(), height(), Gosu::Color::BLUE));
+        return ctx_.image;
     }
 
     void play(bool looping)
     {
+        int result;
         looping_ = looping;
-        libvlc_media_player_play(vlc_media_player_);
+        result = libvlc_media_player_play(vlc_media_player_);
+
+        if (result < 0) {
+            throw std::runtime_error("Failed to play media");
+        }
     }
 
     void pause()
@@ -149,7 +181,7 @@ public:
 
     bool playing()
     {
-        return libvlc_media_player_is_playing(vlc_media_player_);
+        return libvlc_media_player_is_playing(vlc_media_player_) == 1;
     }
 
     bool paused()
@@ -175,11 +207,23 @@ public:
 
     double position()
     {
-        return 0;
+        int result;
+
+        result = libvlc_media_player_get_time(vlc_media_player_);
+
+        if (result < 0 || result == 0) {
+            return 0.0;
+        }
+
+        return result / 1000.0;
     }
 
     void set_position(double position)
     {
+        position = clamp(position, 0.0, length());
+        position *= 1000.0;
+
+        libvlc_media_player_set_time(vlc_media_player_, position);
     }
 
     void update()
@@ -187,16 +231,62 @@ public:
         // Feed frames
         // Feed audio
     }
+
+    void lock()
+    {
+        ctx_.video_lock.lock();
+    }
+
+    void unlock()
+    {
+        ctx_.video_lock.unlock();
+    }
 };
+
+// TODO: Possibly replace this with a global mutex instead of a local one that needs to be manually locked and unlocked for each video
+void Gosu::Video::lock_all()
+{
+    for (size_t i = 0; i < current_videos.size(); i++) {
+        Gosu::Video* video = current_videos.at(i);
+
+        video->lock();
+    }
+}
+
+void Gosu::Video::unlock_all()
+{
+    for (size_t i = 0; i < current_videos.size(); i++) {
+        Gosu::Video* video = current_videos.at(i);
+
+        video->unlock();
+    }
+}
 
 Gosu::Video::Video(const std::string& filename, unsigned image_flags)
 {
     pimpl.reset(new Impl(filename, image_flags));
+
+    current_videos.emplace_back(this);
 }
 
 Gosu::Video::Video(const std::string& filename, double width, double height, unsigned image_flags)
 {
     pimpl.reset(new Impl(filename, width, height, image_flags));
+
+    current_videos.emplace_back(this);
+}
+
+Gosu::Video::~Video()
+{
+    for (size_t i = 0; i < current_videos.size(); i++) {
+        Gosu::Video* video = current_videos.at(i);
+
+        if (video == this) {
+            current_videos.erase(current_videos.begin() + i);
+
+            break;
+        }
+    }
 }
 
 unsigned Gosu::Video::width() const
@@ -212,21 +302,21 @@ unsigned Gosu::Video::height() const
 void Gosu::Video::draw(double x, double y, ZPos z, double scale_x, double scale_y, Color c,
                        BlendMode mode) const
 {
-    pimpl->image()->draw(x, y, z, scale_x, scale_y, c, mode);
+    pimpl->image().draw(x, y, z, scale_x, scale_y, c, mode);
 }
 
 void Gosu::Video::draw_rot(double x, double y, ZPos z, double angle, double center_x,
                            double center_y, double scale_x, double scale_y, Color c,
                            BlendMode mode) const
 {
-    pimpl->image()->draw_rot(x, y, z, angle, center_x, center_y, scale_x, scale_y, c, mode);
+    pimpl->image().draw_rot(x, y, z, angle, center_x, center_y, scale_x, scale_y, c, mode);
 }
 
 void Gosu::Video::draw_as_quad(double x1, double y1, unsigned color1, double x2, double y2,
                                unsigned color2, double x3, double y3, unsigned color3, double x4,
                                double y4, unsigned color4, double z, BlendMode mode) const
 {
-    pimpl->image()->data().draw(x1, y1, color1, x2, y2, color2, x3, y3, color3, x4, y4, color4, z,
+    pimpl->image().data().draw(x1, y1, color1, x2, y2, color2, x3, y3, color3, x4, y4, color4, z,
                                 mode);
 }
 
@@ -285,9 +375,19 @@ void Gosu::Video::update()
     return pimpl->update();
 }
 
-Gosu::Image* image()
+void Gosu::Video::lock()
 {
-    return image();
+    pimpl->lock();
+}
+
+void Gosu::Video::unlock()
+{
+    return pimpl->unlock();
+}
+
+Gosu::Image Gosu::Video::image()
+{
+    return pimpl->image();
 }
 
 #endif

--- a/src/Video.cpp
+++ b/src/Video.cpp
@@ -1,0 +1,149 @@
+// TODO: Change to #ifdef when done implementing!
+#ifndef USE_FFMPEG
+
+#include <Gosu/Graphics.hpp>
+#include <Gosu/IO.hpp>
+#include <Gosu/Math.hpp>
+#include <Gosu/Platform.hpp>
+#include <Gosu/Utility.hpp>
+#include <Gosu/Video.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <cstdlib>
+
+struct Gosu::Video::Impl
+{
+    double volume_ = 1.0;
+    bool looping_ = false;
+
+    void apply_volume()
+    {
+      // Do stuff
+      // volume();
+    }
+
+public:
+    explicit Impl(const std::string& filename, unsigned image_flags)
+    {
+        // TODO: create a couple of Gosu::Image/Bitmap's to swap back and furth
+        // as video frames are loaded
+    }
+
+    explicit Impl(const std::string& filename, double width, double height, unsigned image_flags)
+    {
+
+    }
+
+    // TODO: clean up
+    ~Impl()
+    {
+    }
+
+    void play(bool looping)
+    {
+        looping_ = looping;
+    }
+
+    void pause()
+    {
+    }
+
+    void stop()
+    {
+    }
+
+    bool playing()
+    {
+    }
+
+    bool paused()
+    {
+    }
+
+    double volume() const
+    {
+        return volume_;
+    }
+
+    void set_volume(double volume)
+    {
+        volume_ = clamp(volume, 0.0, 1.0);
+        apply_volume();
+    }
+};
+
+Gosu::Video::Video(const std::string& filename, unsigned image_flags)
+{
+    pimpl.reset(new Impl(filename, imge_flags));
+}
+
+Gosu::Video::Video(const std::string& filename, double width, double height, unsigned image_flags)
+{
+    pimpl.reset(new Impl(filename, width, height, image_flags));
+}
+
+unsigned Gosu::Video::width() const
+{
+}
+
+unsigned Gosu::Video::height() const
+{
+}
+
+void Gosu::Video::draw(double x, double y, ZPos z, double scale_x, double scale_y, Color c,
+                       BlendMode mode) const
+{
+}
+
+void Gosu::Video::draw_rot(double x, double y, ZPos z, double angle, double center_x,
+                           double center_y, double scale_x, double scale_y, Color c,
+                           BlendMode mode) const
+{
+}
+
+void Gosu::Video::play(bool looping)
+{
+}
+
+void Gosu::Video::pause()
+{
+}
+
+void Gosu::Video::stop()
+{
+}
+
+bool Gosu::Video::playing() const
+{
+}
+
+bool Gosu::Video::paused() const
+{
+}
+
+double Gosu::Video::volume() const
+{
+}
+
+void Gosu::Video::set_volume(double volume)
+{
+}
+
+double Gosu::Video::length() const
+{
+}
+
+double Gosu::Video::position() const
+{
+}
+
+void Gosu::Video::set_position(double position)
+{
+}
+
+void Gosu::Video::update()
+{
+}
+
+#endif

--- a/src/Video.cpp
+++ b/src/Video.cpp
@@ -1,49 +1,80 @@
-#ifdef ENABLE_FFMPEG
+#ifdef GOSU_ENABLE_VIDEO
 
+#include "GraphicsImpl.hpp"
 #include <Gosu/Video.hpp>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_syswm.h>
 
 struct Gosu::Video::Impl
 {
+    struct context
+    {
+        bool locked = false;
+        Gosu::Bitmap* bitmap;
+    };
+
     double volume_ = 1.0;
     bool looping_ = false;
-    int image_width_ = 0, image_height_ = 0;
+    double duration_;
+    unsigned video_width_ = 0, video_height_ = 0;
+    unsigned image_width_ = 0, image_height_ = 0;
     unsigned image_flags_ = ImageFlags::IF_SMOOTH;
 
-    AVFormatContext* fmt_ctx = nullptr;
-    AVDictionaryEntry* tag = nullptr;
+    libvlc_instance_t *vlc_instance_;
+    libvlc_media_t *vlc_media_;
+    libvlc_media_player_t *vlc_media_player_;
 
-    const AVCodec *codec;
-    AVCodecParser *parser;
-    AVCodecParserContext *context = nullptr;
+    static void* lock_video(void* data, void** p_pixels)
+    {
+        struct context* ctx = (context *) data;
+
+        ctx->locked = true;
+        *p_pixels = ctx->bitmap->data();
+        return NULL;
+    }
+
+    static void unlock_video(void* data, void* id, void* const* p_pixels)
+    {
+        struct context* ctx = (context*) data;
+
+        assert(id == NULL);
+    }
+    static void display(void* data, void* id)
+    {
+
+    }
 
     void apply_volume()
     {
-      // Do stuff
-      // volume();
+        // Do stuff
+        // volume();
     }
 
     void initialize_video(const std::string filename)
     {
-        // First thing to do is check if file exists, then if we can actually load/play it (supported codec)
-        int ret;
+        struct context context;
 
-        printf("Video file: %s\n", filename.c_str());
+        vlc_instance_ = libvlc_new(0, NULL);
+        vlc_media_ = libvlc_media_new_path(vlc_instance_, filename.c_str());
+        vlc_media_player_ = libvlc_media_player_new_from_media(vlc_media_);
 
-        if ((ret = avformat_open_input(&fmt_ctx, filename.c_str(), NULL, NULL))) return;
+        // Start playing for a few microseconds to get metadata
+        libvlc_media_player_play(vlc_media_player_);
 
-        puts("Successfully opened input!");
+        libvlc_state_t vlc_media_player_state_ = libvlc_media_player_get_state(vlc_media_player_);
 
-        if ((ret = avformat_find_stream_info(fmt_ctx, NULL)) < 0) {
-            av_log(NULL, AV_LOG_ERROR, "Cannot find stream information\n");
-            return;
+        // Block main thread while VLC buffers media
+        while (libvlc_media_player_get_length(vlc_media_player_) <= 0) {
         }
 
-        puts("Successfully read stream info");
+        duration_ = libvlc_media_player_get_length(vlc_media_player_) / 1000.0;
+        libvlc_video_get_size(vlc_media_player_, 0, &video_width_, &video_height_);
 
-        while ((tag = av_dict_get(fmt_ctx->metadata, "", tag, AV_DICT_IGNORE_SUFFIX)))
-            printf("%s=%s\n", tag->key, tag->value);
+        libvlc_media_player_stop(vlc_media_player_);
 
-        avformat_close_input(&fmt_ctx);
+        // TODO: Resolve segfault use this callback instead of making VLC draw to window
+        // libvlc_video_set_callbacks(vlc_media_player_, lock_video, nullptr, nullptr, nullptr);
+        // libvlc_video_set_format(vlc_media_player_, "RGBA", video_width_, video_height_, video_width_ * 4);
     }
 
 public:
@@ -69,11 +100,30 @@ public:
     // TODO: clean up
     ~Impl()
     {
+        libvlc_media_player_stop(vlc_media_player_);
+        libvlc_release(vlc_instance_);
+    }
+
+    unsigned width()
+    {
+        return video_width_;
+    }
+
+    unsigned height()
+    {
+        return video_height_;
+    }
+
+    Gosu::Image* image()
+    {
+        return new Gosu::Image(Bitmap(width(), height(), Gosu::Color::BLUE));
     }
 
     void play(bool looping)
     {
         looping_ = looping;
+        libvlc_media_player_set_xwindow(vlc_media_player_, SDL_GetWindowID(Gosu::shared_window()));
+        libvlc_media_player_play(vlc_media_player_);
     }
 
     void pause()
@@ -82,14 +132,18 @@ public:
 
     void stop()
     {
+        libvlc_media_player_set_xwindow(vlc_media_player_, 0);
+        libvlc_media_player_stop(vlc_media_player_);
     }
 
     bool playing()
     {
+        return false;
     }
 
     bool paused()
     {
+        return false;
     }
 
     double volume() const
@@ -101,6 +155,26 @@ public:
     {
         volume_ = clamp(volume, 0.0, 1.0);
         apply_volume();
+    }
+
+    double length()
+    {
+        return duration_;
+    }
+
+    double position()
+    {
+        return 0;
+    }
+
+    void set_position(double position)
+    {
+    }
+
+    void update()
+    {
+        // Feed frames
+        // Feed audio
     }
 };
 
@@ -116,65 +190,93 @@ Gosu::Video::Video(const std::string& filename, double width, double height, uns
 
 unsigned Gosu::Video::width() const
 {
+    return pimpl->width();
 }
 
 unsigned Gosu::Video::height() const
 {
+    return pimpl->height();
 }
 
 void Gosu::Video::draw(double x, double y, ZPos z, double scale_x, double scale_y, Color c,
                        BlendMode mode) const
 {
+    pimpl->image()->draw(x, y, z, scale_x, scale_y, c, mode);
 }
 
 void Gosu::Video::draw_rot(double x, double y, ZPos z, double angle, double center_x,
                            double center_y, double scale_x, double scale_y, Color c,
                            BlendMode mode) const
 {
+    pimpl->image()->draw_rot(x, y, z, angle, center_x, center_y, scale_x, scale_y, c, mode);
+}
+
+void Gosu::Video::draw_as_quad(double x1, double y1, unsigned color1, double x2, double y2,
+                               unsigned color2, double x3, double y3, unsigned color3, double x4,
+                               double y4, unsigned color4, double z, BlendMode mode) const
+{
+    pimpl->image()->data().draw(x1, y1, color1, x2, y2, color2, x3, y3, color3, x4, y4, color4, z,
+                                mode);
 }
 
 void Gosu::Video::play(bool looping)
 {
+    pimpl->play(looping);
 }
 
 void Gosu::Video::pause()
 {
+    pimpl->pause();
 }
 
 void Gosu::Video::stop()
 {
+    pimpl->stop();
 }
 
 bool Gosu::Video::playing() const
 {
+    return pimpl->playing();
 }
 
 bool Gosu::Video::paused() const
 {
+    return pimpl->paused();
 }
 
 double Gosu::Video::volume() const
 {
+    return pimpl->volume();
 }
 
 void Gosu::Video::set_volume(double volume)
 {
+    pimpl->set_volume(volume);
 }
 
 double Gosu::Video::length() const
 {
+    return pimpl->length();
 }
 
 double Gosu::Video::position() const
 {
+    return pimpl->position();
 }
 
 void Gosu::Video::set_position(double position)
 {
+    pimpl->set_position(position);
 }
 
 void Gosu::Video::update()
 {
+    return pimpl->update();
+}
+
+Gosu::Image* image()
+{
+    return image();
 }
 
 #endif

--- a/src/Video.cpp
+++ b/src/Video.cpp
@@ -53,6 +53,8 @@ struct Gosu::Video::Impl
     {
         puts("REACHED DISPLAY");
         struct context* ctx = (context*) data;
+
+        ctx->image = new Gosu::Image(*ctx->bitmap);
     }
 
     void apply_volume()

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -341,6 +341,8 @@ bool Gosu::Window::tick()
         }
     }
 
+    Video::lock_all();
+
     Song::update();
 
     input().update();
@@ -358,6 +360,8 @@ bool Gosu::Window::tick()
 
         SDL_GL_SwapWindow(shared_window());
     }
+
+    Video::unlock_all();
 
     if (pimpl->state == Impl::CLOSING) {
         pimpl->state = Impl::CLOSED;

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -341,7 +341,9 @@ bool Gosu::Window::tick()
         }
     }
 
+    #ifdef GOSU_ENABLE_VIDEO
     Video::lock_all();
+    #endif
 
     Song::update();
 
@@ -361,7 +363,9 @@ bool Gosu::Window::tick()
         SDL_GL_SwapWindow(shared_window());
     }
 
+    #ifdef GOSU_ENABLE_VIDEO
     Video::unlock_all();
+    #endif
 
     if (pimpl->state == Impl::CLOSING) {
         pimpl->state = Impl::CLOSED;


### PR DESCRIPTION
Currently a stub.

An ffmpeg/libvlc backed implementation that'll emulate the `Gosu::Image` and `Gosu::Song` public interfaces.

`Gosu::Window::tick()` will likely need to call `Gosu::Video::update()` on all videos; A static vector in `Gosu::Video` can host and maintain the list.

The implementation is wrapped in an `#ifdef` to allow `Gosu::Video` to be an optional feature.