### PR TITLE
Add call to alSourcei to Gosu::Song::Impl::stop() (ref: #618)

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -148,6 +148,8 @@ public:
 
         alSourceStop(source);
 
+        alSourcei(source, AL_BUFFER, AL_NONE);
+
         // Dequeue all buffers for this source.
         // The number of QUEUED buffers apparently includes the number of PROCESSED ones,
         // so getting rid of the QUEUED ones is enough.


### PR DESCRIPTION
This fixes the major issues of #618 with the caveat that mojoAL's `AL_BUFFERS_QUEUED` may be returning an incorrect value, causing a song that has been stopped and had `play()` called will have garbage data from that previous run for the first-ish sample.

https://github.com/icculus/mojoAL/blob/42035035b4e5debb6fe30e475683da2c30e51326/mojoal.c#L3976-L3977
