### PR TITLE
Link to the correct libsdl on mac

### DIFF
--- a/ext/gosu/extconf.rb
+++ b/ext/gosu/extconf.rb
@@ -74,9 +74,12 @@ elsif macos
   $LDFLAGS << " #{`sdl2-config --static-libs`.chomp} -framework OpenGL -framework Metal"
   # And yet another hack: `sdl2-config --static-libs` uses `-lSDL2` instead of linking to the static library,
   # even if it exists. -> Manually replace it. (Ugh!)
-  %w(/usr/local/lib/libSDL2.a /opt/homebrew/opt/sdl2/lib/libSDL2.a).each do |static_lib|
-    $LDFLAGS.sub! " -lSDL2 ", " #{static_lib} " if File.exist? static_lib
-  end
+  static_lib = if RbConfig::CONFIG["target_cpu"] == "arm64"
+                 "/opt/homebrew/opt/sdl2/lib/libSDL2.a"
+               else
+                 "/usr/local/lib/libSDL2.a"
+               end
+  $LDFLAGS.sub! " -lSDL2 ", " #{static_lib} " if File.exist? static_lib
 
   # Disable building of 32-bit slices in Apple's Ruby.
   # (RbConfig::CONFIG['CXXFLAGS'] on 10.11: -arch x86_64 -arch i386 -g -Os -pipe)


### PR DESCRIPTION
Sometimes on an arm64 (apple silicon) mac, an old x86 homebrew with libsdl may exist in addition to the arm64 version of libsdl. This PR ensures that gosu is linked against the correct architecture even when both versions of libsdl exist. Previously the x86 will be favoured which resulted in a runtime error `symbol not found in flat namespace '_SDL_AtomicAdd'`