### PR TITLE
Fix sleeping bug

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -28,6 +28,7 @@ Checks: >-
   -hicpp-vararg,
   -llvm-*,
   -llvmlibc-*,
+  -misc-const-correctness,
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
   -modernize-avoid-c-arrays,

--- a/ext/gosu/gosu.i
+++ b/ext/gosu/gosu.i
@@ -406,6 +406,7 @@ namespace Gosu
 %include "../../include/Gosu/Version.hpp"
 
 // Miscellaneous functions (timing, math)
+%ignore Gosu::sleep;
 %include "../../include/Gosu/Timing.hpp"
 %ignore Gosu::distance_sqr;
 %ignore Gosu::wrap;

--- a/include/Gosu/Input.hpp
+++ b/include/Gosu/Input.hpp
@@ -24,7 +24,7 @@ namespace Gosu
 
     /// Manages initialization and shutdown of the input system.
     /// Only one Input instance can exist per application.
-    class Input : Noncopyable
+    class Input : private Noncopyable
     {
         struct Impl;
         std::unique_ptr<Impl> pimpl;

--- a/include/Gosu/TextInput.hpp
+++ b/include/Gosu/TextInput.hpp
@@ -2,6 +2,7 @@
 
 #include <Gosu/Fwd.hpp>
 #include <Gosu/Platform.hpp>
+#include <Gosu/Utility.hpp>
 #include <memory>
 #include <string>
 
@@ -15,11 +16,10 @@ namespace Gosu
     /// build a text that can be accessed via TextInput::text().
     /// A TextInput object has no built-in UI. It is up to you to actually draw a text field.
     /// TextInput only provides a portable base for your own GUI to build upon.
-    class TextInput
+    class TextInput : private Noncopyable
     {
         struct Impl;
-        // Non-movable (const) to avoid dangling references to TextInput instances.
-        const std::unique_ptr<Impl> m_impl;
+        std::unique_ptr<Impl> m_impl;
 
     public:
         TextInput();

--- a/include/Gosu/Timing.hpp
+++ b/include/Gosu/Timing.hpp
@@ -2,6 +2,9 @@
 
 namespace Gosu
 {
+    /// Freezes the current thread for the given amount of milliseconds.
+    void sleep(unsigned milliseconds);
+
     /// Returns the milliseconds since first calling this function.
     /// Can wrap after running for a long time.
     unsigned long milliseconds();

--- a/include/Gosu/Window.hpp
+++ b/include/Gosu/Window.hpp
@@ -3,6 +3,7 @@
 #include <Gosu/Fwd.hpp>
 #include <Gosu/Input.hpp>
 #include <Gosu/Platform.hpp>
+#include <Gosu/Utility.hpp>
 #include <memory>
 #include <string>
 
@@ -19,10 +20,10 @@ namespace Gosu
     /// Convenient all-in-one class that serves as the foundation of a standard Gosu application.
     /// Manages initialization of all of Gosu's core components and provides timing functionality.
     /// Note that you can only use one instance of this class at the same time.
-    class Window
+    class Window : private Noncopyable
     {
         struct Impl;
-        const std::unique_ptr<Impl> m_impl;
+        std::unique_ptr<Impl> m_impl;
 
     public:
         /// Constructs a Window.

--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -13,7 +13,7 @@ static Gosu::Song* cur_song = nullptr;
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static bool cur_song_looping;
 
-struct Gosu::Sample::Impl : Gosu::Noncopyable
+struct Gosu::Sample::Impl : private Gosu::Noncopyable
 {
     ALuint buffer;
 
@@ -76,7 +76,7 @@ Gosu::Channel Gosu::Sample::play_pan(double pan, double volume, double speed, bo
 }
 
 // AudioFile impl
-struct Gosu::Song::Impl : Gosu::Noncopyable
+struct Gosu::Song::Impl : private Gosu::Noncopyable
 {
 private:
     double m_volume = 1.0;

--- a/src/AudioFileAudioToolbox.cpp
+++ b/src/AudioFileAudioToolbox.cpp
@@ -35,7 +35,7 @@ static void throw_os_error(OSStatus status, unsigned line)
 
 #define CHECK_OS(status) do { if (status) throw_os_error(status, __LINE__); } while (0)
 
-struct Gosu::AudioFile::Impl : Gosu::Noncopyable
+struct Gosu::AudioFile::Impl : private Gosu::Noncopyable
 {
     Buffer buffer;
     AudioFileID file_id;

--- a/src/AudioFileSDLSound.cpp
+++ b/src/AudioFileSDLSound.cpp
@@ -14,7 +14,7 @@
 #include <mutex>
 #include <vector>
 
-struct Gosu::AudioFile::Impl : Gosu::Noncopyable
+struct Gosu::AudioFile::Impl : private Gosu::Noncopyable
 {
     Buffer buffer;
 

--- a/src/BlockAllocator.cpp
+++ b/src/BlockAllocator.cpp
@@ -4,7 +4,7 @@
 #include <vector>
 using namespace std;
 
-struct Gosu::BlockAllocator::Impl : Gosu::Noncopyable
+struct Gosu::BlockAllocator::Impl : private Gosu::Noncopyable
 {
     unsigned width, height;
 

--- a/src/FileUnix.cpp
+++ b/src/FileUnix.cpp
@@ -16,7 +16,7 @@
 
 using namespace std;
 
-struct Gosu::File::Impl : Gosu::Noncopyable
+struct Gosu::File::Impl : private Gosu::Noncopyable
 {
     int fd = -1;
     void* mapping = MAP_FAILED;

--- a/src/FileWin.cpp
+++ b/src/FileWin.cpp
@@ -9,7 +9,7 @@ using namespace std;
 
 // TODO: Error checking
 
-struct Gosu::File::Impl : Gosu::Noncopyable
+struct Gosu::File::Impl : private Gosu::Noncopyable
 {
     HANDLE handle = INVALID_HANDLE_VALUE;
 

--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -13,7 +13,7 @@
 
 static const int FONT_RENDER_SCALE = 2;
 
-struct Gosu::Font::Impl : Gosu::Noncopyable
+struct Gosu::Font::Impl : private Gosu::Noncopyable
 {
     std::string name;
     int height;

--- a/src/Graphics.cpp
+++ b/src/Graphics.cpp
@@ -42,7 +42,7 @@ namespace Gosu
     }
 }
 
-struct Gosu::Graphics::Impl : Gosu::Noncopyable
+struct Gosu::Graphics::Impl : private Gosu::Noncopyable
 {
     unsigned virt_width = 0, virt_height = 0;
     unsigned phys_width = 0, phys_height = 0;

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -36,7 +36,7 @@ static vector<shared_ptr<SDL_GameController>> open_game_controllers;
 // Stores joystick instance id or -1 if empty
 static array<int, Gosu::NUM_GAMEPADS> gamepad_slots = {-1, -1, -1, -1};
 
-struct Gosu::Input::Impl : Gosu::Noncopyable
+struct Gosu::Input::Impl : private Gosu::Noncopyable
 {
     struct InputEvent
     {

--- a/src/InputUIKit.cpp
+++ b/src/InputUIKit.cpp
@@ -7,7 +7,7 @@
 #import <UIKit/UIKit.h>
 using namespace std;
 
-struct Gosu::Input::Impl : Gosu::Noncopyable
+struct Gosu::Input::Impl : private Gosu::Noncopyable
 {
     UIView* view = nil;
     TextInput* text_input = nullptr;

--- a/src/Macro.cpp
+++ b/src/Macro.cpp
@@ -4,7 +4,7 @@
 #include "DrawOpQueue.hpp"
 #include <stdexcept>
 
-struct Gosu::Macro::Impl : Gosu::Noncopyable
+struct Gosu::Macro::Impl : private Gosu::Noncopyable
 {
     VertexArrays vertex_arrays;
     int width, height;

--- a/src/TextInput.cpp
+++ b/src/TextInput.cpp
@@ -7,7 +7,7 @@
 #include <SDL.h>
 #endif
 
-struct Gosu::TextInput::Impl : Gosu::Noncopyable
+struct Gosu::TextInput::Impl : private Gosu::Noncopyable
 {
     std::string text;
 

--- a/src/TimingApple.cpp
+++ b/src/TimingApple.cpp
@@ -2,6 +2,12 @@
 #if defined(GOSU_IS_MAC)
 
 #include <Gosu/Timing.hpp>
+#include <unistd.h>
+
+void Gosu::sleep(unsigned milliseconds)
+{
+    usleep(milliseconds * 1000);
+}
 
 // Thanks to this blog for the unconvoluted code example:
 // http://shiftedbits.org/2008/10/01/mach_absolute_time-on-the-iphone/
@@ -11,7 +17,7 @@
 unsigned long Gosu::milliseconds()
 {
     static mach_timebase_info_data_t info;
-    static uint64_t first_tick = [] {
+    static const uint64_t first_tick = [] {
         mach_timebase_info(&info);
         return mach_absolute_time();
     }();

--- a/src/TimingUnix.cpp
+++ b/src/TimingUnix.cpp
@@ -12,16 +12,12 @@ void Gosu::sleep(unsigned milliseconds)
 
 unsigned long Gosu::milliseconds()
 {
-    static const unsigned long start = 0;
-
     timeval tp;
     gettimeofday(&tp, nullptr);
+    unsigned long ms = tp.tv_usec / 1000UL + tp.tv_sec * 1000UL;
 
-    if (start == 0) {
-        start = tp.tv_usec / 1000UL + tp.tv_sec * 1000UL;
-    }
-
-    return tp.tv_usec / 1000UL + tp.tv_sec * 1000UL - start;
+    static unsigned long start = ms;
+    return ms - start;
 }
 
 #endif

--- a/src/TimingUnix.cpp
+++ b/src/TimingUnix.cpp
@@ -3,10 +3,16 @@
 
 #include <Gosu/Timing.hpp>
 #include <sys/time.h>
+#include <unistd.h>
+
+void Gosu::sleep(unsigned milliseconds)
+{
+    usleep(milliseconds * 1000);
+}
 
 unsigned long Gosu::milliseconds()
 {
-    static unsigned long start = 0;
+    static const unsigned long start = 0;
 
     timeval tp;
     gettimeofday(&tp, nullptr);

--- a/src/TimingWin.cpp
+++ b/src/TimingWin.cpp
@@ -6,7 +6,7 @@
 
 void Gosu::sleep(unsigned milliseconds)
 {
-    SleepEx(milliseconds, FALSE);
+    Sleep(milliseconds);
 }
 
 unsigned long Gosu::milliseconds()

--- a/src/TimingWin.cpp
+++ b/src/TimingWin.cpp
@@ -4,9 +4,14 @@
 #include <Gosu/Timing.hpp>
 #include <windows.h>
 
+void Gosu::sleep(unsigned milliseconds)
+{
+    SleepEx(milliseconds, FALSE);
+}
+
 unsigned long Gosu::milliseconds()
 {
-    static unsigned long start = [] {
+    static const unsigned long start = [] {
         timeBeginPeriod(1);
         return timeGetTime();
     }();

--- a/src/TrueTypeFont.cpp
+++ b/src/TrueTypeFont.cpp
@@ -9,7 +9,7 @@
 #define STB_TRUETYPE_IMPLEMENTATION
 #include <stb_truetype.h>
 
-struct Gosu::TrueTypeFont::Impl : Gosu::Noncopyable
+struct Gosu::TrueTypeFont::Impl : private Gosu::Noncopyable
 {
     stbtt_fontinfo info{};
     std::shared_ptr<TrueTypeFont> fallback;

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -71,7 +71,7 @@ namespace Gosu
     }
 }
 
-struct Gosu::Window::Impl : Gosu::Noncopyable
+struct Gosu::Window::Impl : private Gosu::Noncopyable
 {
     bool fullscreen = false;
     double update_interval = 0;

--- a/src/WindowUIKit.cpp
+++ b/src/WindowUIKit.cpp
@@ -4,7 +4,7 @@
 #include "GosuViewController.hpp"
 #include <Gosu/Gosu.hpp>
 
-struct Gosu::Window::Impl : Gosu::Noncopyable
+struct Gosu::Window::Impl : private Gosu::Noncopyable
 {
     UIWindow* window;
     GosuViewController* controller;


### PR DESCRIPTION
This fixes the changed sleeping behavior on Windows which was introduced by replacing the Win32 Sleep() function with std::chrono::sleep_for in #622.