### PR TITLE
Replace use of this_thread::sleep_for by Win32 Sleep()

### DIFF
--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -275,6 +275,9 @@ void Gosu::Window::show()
             unsigned long tick_time = milliseconds() - time_before_tick;
             long sleep_time = static_cast<long>(update_interval() - static_cast<double>(tick_time));
             if (sleep_time >= 1) {
+                // Use Gosu::sleep instead of std::this_thread::sleep_for because Win32 Sleep()
+                // results in better behavior here, sleep_for causes FPS to drop from 60 to <50.
+                // (This is also the reason why Gosu::sleep still exists.)
                 Gosu::sleep(sleep_time);
             }
 

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -11,7 +11,6 @@
 #include <SDL.h>
 #include <algorithm>
 #include <stdexcept>
-#include <thread>
 
 namespace Gosu
 {
@@ -273,10 +272,10 @@ void Gosu::Window::show()
     try {
         while (tick()) {
             // Sleep to keep this loop from eating 100% CPU.
-            long tick_time = milliseconds() - time_before_tick;
-            long sleep_time = static_cast<long>(update_interval() - tick_time);
+            unsigned long tick_time = milliseconds() - time_before_tick;
+            long sleep_time = static_cast<long>(update_interval() - static_cast<double>(tick_time));
             if (sleep_time >= 1) {
-                std::this_thread::sleep_for(std::chrono::milliseconds{sleep_time});
+                Gosu::sleep(sleep_time);
             }
 
             time_before_tick = milliseconds();


### PR DESCRIPTION
This completes the botched fix from 1.4.4, but still needs comments to explain why we don't use this_thread.