### PR TITLE
Use SDL_GameControllerSetPlayerIndex and SDL_JoystickSetPlayerIndex 

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,14 +12,14 @@ jobs:
   build:
     strategy:
       matrix:
-        platform: [ubuntu-latest, ubuntu-18.04, macos-latest, macos-10.15]
+        platform: [ubuntu-latest, ubuntu-20.04, macos-latest, macos-10.15]
     runs-on: ${{ matrix.platform }}
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Install dependencies (Ubuntu)
-        if: matrix.platform == 'ubuntu-latest' || matrix.platform == 'ubuntu-18.04'
+        if: matrix.platform == 'ubuntu-latest' || matrix.platform == 'ubuntu-20.04'
         run: sudo apt-get update && sudo apt-get install -y libsdl2-dev libgl1-mesa-dev libgmp-dev libfontconfig1-dev libgtest-dev
 
       - name: Install dependencies (macOS)

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -149,7 +149,9 @@ struct Gosu::Input::Impl : private Gosu::Noncopyable
                         if (gamepad_instance_id_is_known(joystick_instance_id)) {
                             return true;
                         }
+#if SDL_VERSION_ATLEAST(2, 0, 12)
                         SDL_GameControllerSetPlayerIndex(game_controller, gamepad_slot);
+#endif
                         open_game_controllers.emplace_back(
                             shared_ptr<SDL_GameController>(game_controller, SDL_GameControllerClose)
                         );
@@ -162,7 +164,9 @@ struct Gosu::Input::Impl : private Gosu::Noncopyable
                     if (gamepad_instance_id_is_known(joystick_instance_id)) {
                         return true;
                     }
+#if SDL_VERSION_ATLEAST(2, 0, 12)
                     SDL_JoystickSetPlayerIndex(joystick, gamepad_slot);
+#endif
                     open_joysticks.emplace_back(
                         shared_ptr<SDL_Joystick>(joystick, SDL_JoystickClose)
                     );


### PR DESCRIPTION
Use `SDL_GameControllerSetPlayerIndex` and `SDL_JoystickSetPlayerIndex` to have SDL set gamepad LED(s), refactored a bit to use the `event->jdevice.which` instead of iterating over known joysticks: fixes `wireless xbox 360 controller` from appearing twice if connected after program starts.

> This function is available since SDL 2.0.12.