### PR TITLE
Fixes missing <stdexcept> header

### DIFF
--- a/src/AudioFileSDLSound.cpp
+++ b/src/AudioFileSDLSound.cpp
@@ -13,6 +13,7 @@
 #include <memory>
 #include <mutex>
 #include <vector>
+#include <stdexcept>
 
 struct Gosu::AudioFile::Impl : private Gosu::Noncopyable
 {

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <array>
 #include <mutex>
+#include <stdexcept>
 using namespace std;
 
 static void require_sdl_video()


### PR DESCRIPTION
Found another spot that needed to be patched

```
#0 15.96 compiling ../../src/Audio.cpp
#0 15.96 compiling ../../src/AudioFileAudioToolbox.cpp
#0 15.96 compiling ../../src/AudioFileSDLSound.cpp
#0 15.96 compiling ../../src/AudioImpl.cpp
#0 15.96 compiling ../../src/Bitmap.cpp
#0 15.96 compiling ../../src/BitmapIO.cpp
#0 15.96 compiling ../../src/BlockAllocator.cpp
#0 15.96 compiling ../../src/Channel.cpp
#0 15.96 compiling ../../src/Color.cpp
#0 15.96 compiling ../../src/DirectoriesApple.cpp
#0 15.96 compiling ../../src/DirectoriesUnix.cpp
#0 15.96 compiling ../../src/DirectoriesWin.cpp
#0 15.96 compiling ../../src/FileUnix.cpp
#0 15.96 ../../src/FileUnix.cpp: In member function ‘virtual void Gosu::File::resize(size_t)’:
#0 15.96 ../../src/FileUnix.cpp:76:14: warning: ignoring return value of ‘int ftruncate(int, __off_t)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
#0 15.96    76 |     ftruncate(pimpl->fd, new_size);
#0 15.96       |     ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
#0 15.96 ../../src/FileUnix.cpp: In member function ‘virtual void Gosu::File::read(size_t, size_t, void*) const’:
#0 15.96 ../../src/FileUnix.cpp:88:15: warning: ignoring return value of ‘ssize_t read(int, void*, size_t)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
#0 15.96    88 |         ::read(pimpl->fd, dest_buffer, length);
#0 15.96       |         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#0 15.96 ../../src/FileUnix.cpp: In member function ‘virtual void Gosu::File::write(size_t, size_t, const void*)’:
#0 15.96 ../../src/FileUnix.cpp:96:12: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
#0 15.96    96 |     ::write(pimpl->fd, source_buffer, length);
#0 15.96       |     ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#0 15.96 compiling ../../src/FileWin.cpp
#0 15.96 compiling ../../src/Font.cpp
#0 15.96 compiling ../../src/GosuGLView.cpp
#0 15.96 compiling ../../src/GosuViewController.cpp
#0 15.96 compiling ../../src/Graphics.cpp
#0 15.96 compiling ../../src/IO.cpp
#0 15.96 compiling ../../src/Image.cpp
#0 15.96 compiling ../../src/Input.cpp
#0 15.96 ../../src/Input.cpp: In static member function ‘static double Gosu::Input::axis(Gosu::Button)’:
#0 15.96 ../../src/Input.cpp:604:20: error: ‘out_of_range’ is not a member of ‘std’
#0 15.96   604 |         throw std::out_of_range("Invalid axis ID: " + std::to_string(btn));
#0 15.96       |                    ^~~~~~~~~~~~
#0 15.96 ../../src/Input.cpp:16:1: note: ‘std::out_of_range’ is defined in header ‘<stdexcept>’; did you forget to ‘#include <stdexcept>’?
#0 15.96    15 | #include <mutex>
#0 15.96   +++ |+#include <stdexcept>
#0 15.96    16 | using namespace std;
#0 15.96 make: *** [Makefile:238: Input.o] Error 1
#0 15.96 
#0 15.96 make failed, exit code 2
```