### PR TITLE
Refactor and test Bitmap and Color, introduce Gosu::Rect (C++ only)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,85 +1,37 @@
-BasedOnStyle: LLVM
-AccessModifierOffset: -4
+BasedOnStyle: WebKit
+
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
-AlignOperands: Align
-AllowAllArgumentsOnNextLine: false
-AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortBlocksOnASingleLine: Never
-AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: InlineOnly
-AllowShortIfStatementsOnASingleLine: WithoutElse
-AllowShortLambdasOnASingleLine: All
-AllowShortLoopsOnASingleLine: true
-AlwaysBreakAfterReturnType: None
-AlwaysBreakTemplateDeclarations: Yes
 BreakBeforeBraces: Custom
+BreakConstructorInitializers: BeforeColon
 BraceWrapping:
-  AfterCaseLabel: false
   AfterClass: true
-  AfterControlStatement: Never
   AfterEnum: true
   AfterFunction: true
   AfterNamespace: true
   AfterStruct: true
   AfterUnion: true
-  BeforeCatch: false
-  BeforeElse: true
-  IndentBraces: false
-  SplitEmptyFunction: true
-  SplitEmptyRecord: true
-BreakBeforeBinaryOperators: None
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializers: BeforeColon
-BreakInheritanceList: BeforeColon
 ColumnLimit: 100
-CompactNamespaces: false
-ConstructorInitializerIndentWidth: 0
-ContinuationIndentWidth: 8
 IncludeBlocks: Regroup
 IncludeCategories:
-  - Regex:           '^<Gosu/Fwd.hpp>$'
-    Priority:        0
-    SortPriority:    2
-  - Regex:           '^<Gosu/'
-    Priority:        0
-    SortPriority:    3
-  - Regex:           '^"'
-    Priority:        0
-    SortPriority:    4
-  - Regex:           '\.h$'
-    Priority:        0
-    SortPriority:    5
-  - Regex:           '.*'
-    Priority:        0
-    SortPriority:    6
-IndentCaseLabels: true
-IndentPPDirectives: None
-IndentWidth: 4
-FixNamespaceComments: false
-KeepEmptyLinesAtTheStartOfBlocks: false
-MaxEmptyLinesToKeep: 1
+  # Make sure that Google Test comes first, so that the FRIEND_TEST macro works reliably.
+  - Regex: '^<gtest/gtest.h>$'
+    Priority: -1
+  - Regex: '^<Gosu/Fwd.hpp>$'
+    Priority: 0
+    SortPriority: 2
+  - Regex: '^<Gosu/'
+    Priority: 0
+    SortPriority: 3
+  - Regex: '^"'
+    Priority: 0
+    SortPriority: 4
+  - Regex: '\.h$'
+    Priority: 0
+    SortPriority: 5
+  - Regex: '.*'
+    Priority: 0
+    SortPriority: 6
+InsertBraces: true
 NamespaceIndentation: All
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: false
 PackConstructorInitializers: Never
-PointerAlignment: Left
-ReflowComments: false
-SpaceAfterCStyleCast: true
-SpaceAfterLogicalNot: false
-SpaceAfterTemplateKeyword: false
-SpaceBeforeAssignmentOperators: true
-SpaceBeforeCpp11BracedList: false
-SpaceBeforeCtorInitializerColon: true
-SpaceBeforeInheritanceColon: true
-SpaceBeforeParens: ControlStatements
-SpaceBeforeRangeBasedForLoopColon: true
-SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 1
-SpacesInAngles: false
-SpacesInCStyleCastParentheses: false
-SpacesInContainerLiterals: false
-SpacesInParentheses: false
-SpacesInSquareBrackets: false
-TabWidth: 4
-UseTab: Never

--- a/ext/gosu/gosu.i
+++ b/ext/gosu/gosu.i
@@ -639,13 +639,12 @@ namespace Gosu
 }
 
 %ignore Gosu::Image::Image();
-%ignore Gosu::Image::Image(const std::string& filename, unsigned flags);
-%ignore Gosu::Image::Image(const std::string& filename, int src_x, int src_y,
-                           int src_width, int src_height, unsigned flags);
-%ignore Gosu::Image::Image(const Bitmap& source, unsigned flags);
-%ignore Gosu::Image::Image(const Bitmap& source, int src_x, int src_y,
-                           int src_width, int src_height, unsigned flags);
-%ignore Gosu::Image::Image(std::unique_ptr<ImageData>&& data);
+%ignore Gosu::Image::Image(const std::string& filename, unsigned image_flags);
+%ignore Gosu::Image::Image(const std::string& filename, const Rect& source_rect,
+                           unsigned image_flags);
+%ignore Gosu::Image::Image(const Bitmap& source, unsigned image_flags);
+%ignore Gosu::Image::Image(const Bitmap& source, const Rect& source_rect, unsigned image_flags);
+%ignore Gosu::Image::Image(std::unique_ptr<ImageData> data);
 %ignore Gosu::load_tiles;
 %include "../../include/Gosu/Image.hpp"
 %extend Gosu::Image {
@@ -653,9 +652,8 @@ namespace Gosu
     {
         Gosu::Bitmap bmp;
         Gosu::load_bitmap(bmp, source);
-        
-        int src_x = 0, src_y = 0;
-        int src_width = bmp.width(), src_height = bmp.height();
+
+        Gosu::Rect source_rect = Gosu::Rect::covering(bmp);
         unsigned flags = 0;
         
         if (options) {
@@ -684,10 +682,10 @@ namespace Gosu
                                                "Array [x, y, width, height]");
                     }
                     
-                    src_x      = NUM2INT(rb_ary_entry(value, 0));
-                    src_y      = NUM2INT(rb_ary_entry(value, 1));
-                    src_width  = NUM2INT(rb_ary_entry(value, 2));
-                    src_height = NUM2INT(rb_ary_entry(value, 3));
+                    source_rect.x      = NUM2INT(rb_ary_entry(value, 0));
+                    source_rect.y      = NUM2INT(rb_ary_entry(value, 1));
+                    source_rect.width  = NUM2INT(rb_ary_entry(value, 2));
+                    source_rect.height = NUM2INT(rb_ary_entry(value, 3));
                 }
                 else {
                     static bool issued_warning = false;
@@ -699,7 +697,7 @@ namespace Gosu
             }
         }
         
-        return new Gosu::Image(bmp, src_x, src_y, src_width, src_height, flags);
+        return new Gosu::Image(bmp, source_rect, flags);
     }
     
     void draw_as_quad(double x1, double y1, Color c1,
@@ -980,7 +978,7 @@ namespace Gosu
                 for (int x = 0; x < w; ++x) {
                     int scaled_x = x * bmp.width()  / w;
                     int scaled_y = y * bmp.height() / h;
-                    int alpha3bit = bmp.get_pixel(scaled_x, scaled_y).alpha / 32;
+                    int alpha3bit = bmp.pixel(scaled_x, scaled_y).alpha / 32;
                     str[(y + 1) * stride + (x + 1)] = " .:ioVM@"[alpha3bit];
                 }
                 str[(y + 1) * stride + (w + 2)] = '\n'; // newline after row of pixels

--- a/include/Gosu/Bitmap.hpp
+++ b/include/Gosu/Bitmap.hpp
@@ -17,8 +17,7 @@ namespace Gosu
     /// Bitmaps have (expensive) value semantics.
     class Bitmap
     {
-        int m_width = 0;
-        int m_height = 0;
+        int m_width = 0, m_height = 0;
         std::vector<Color> m_pixels;
 
     public:

--- a/include/Gosu/Bitmap.hpp
+++ b/include/Gosu/Bitmap.hpp
@@ -7,13 +7,17 @@
 
 namespace Gosu
 {
-    /// A two-dimensional array area of pixels, each represented by a Color value.
+    /// A two-dimensional area of pixels, each represented by a Color value.
+    /// Internally, it is stored as a contiguous array of Gosu::Color, row by row.
+    ///
     /// Bitmaps are typically created only as an intermediate step between loading image files, and
     /// creating Gosu::Image objects from them (i.e. transferring the image into video RAM).
-    /// Has (expensive) value semantics.
+    ///
+    /// Bitmaps have (expensive) value semantics.
     class Bitmap
     {
-        int m_width = 0, m_height = 0;
+        int m_width = 0;
+        int m_height = 0;
         std::vector<Color> m_pixels;
 
     public:
@@ -21,31 +25,17 @@ namespace Gosu
 
         Bitmap(int width, int height, Color c = Color::NONE);
 
-        int width() const
-        {
-            return m_width;
-        }
+        int width() const { return m_width; }
 
-        int height() const
-        {
-            return m_height;
-        }
-
-        void swap(Bitmap& other);
+        int height() const { return m_height; }
 
         void resize(int width, int height, Color c = Color::NONE);
 
         /// Returns the color at the specified position without any bounds checking.
-        Color get_pixel(int x, int y) const
-        {
-            return m_pixels[y * m_width + x];
-        }
+        Color get_pixel(int x, int y) const { return m_pixels[y * m_width + x]; }
 
         /// Sets the pixel at the specified position without any bounds checking.
-        void set_pixel(int x, int y, Color c)
-        {
-            m_pixels[y * m_width + x] = c;
-        }
+        void set_pixel(int x, int y, Color c) { m_pixels[y * m_width + x] = c; }
 
         /// This updates a pixel using the "over" alpha compositing operator, see:
         /// https://en.wikipedia.org/wiki/Alpha_compositing
@@ -57,26 +47,18 @@ namespace Gosu
 
         /// Inserts a portion of a bitmap at the given position. Parts of the inserted bitmap that
         /// would be outside of the target bitmap will be clipped away.
-        void insert(int x, int y, const Bitmap& source,
-                    int src_x, int src_y, int src_width, int src_height);
+        void insert(int x, int y, const Bitmap& source, int src_x, int src_y, int src_width,
+                    int src_height);
 
         /// Direct access to the array of color values.
-        /// The return value is undefined if this bitmap is empty.
-        const Color* data() const
-        {
-            return &m_pixels[0];
-        }
+        const Color* data() const { return m_pixels.data(); }
 
         /// Direct access to the array of color values.
-        /// The return value is undefined if this bitmap is empty.
-        Color* data()
-        {
-            return &m_pixels[0];
-        }
+        Color* data() { return m_pixels.data(); }
 
-        #ifdef FRIEND_TEST
-        FRIEND_TEST(BitmapTests, MemoryManagement);
-        #endif
+#ifdef FRIEND_TEST
+        FRIEND_TEST(BitmapTests, memory_management);
+#endif
     };
 
     /// Loads any supported image into a Bitmap.
@@ -87,14 +69,13 @@ namespace Gosu
     /// Saves a Bitmap to a file.
     void save_image_file(const Bitmap& bitmap, const std::string& filename);
     /// Saves a Bitmap to an arbitrary resource.
-    void save_image_file(const Bitmap& bitmap, Writer writer,
-                         const std::string_view& format_hint = "png");
+    void save_image_file(const Bitmap& bitmap, Writer writer, std::string_view format_hint = "png");
 
     /// Set the alpha value of all pixels which are equal to the color key to zero.
     /// To reduce interpolation artefacts when stretching or rotating the resulting image, the color
-    /// value of these pixels will also be adjusted to the average of their surrounding pixels.
+    /// value of these transparent pixels will be adjusted to the average of their neighbors.
     void apply_color_key(Bitmap& bitmap, Color key);
 
-    Bitmap apply_border_flags(unsigned image_flags, const Bitmap& source,
-                              int src_x, int src_y, int src_width, int src_height);
+    Bitmap apply_border_flags(unsigned image_flags, const Bitmap& source, int src_x, int src_y,
+                              int src_width, int src_height);
 }

--- a/include/Gosu/Bitmap.hpp
+++ b/include/Gosu/Bitmap.hpp
@@ -2,6 +2,7 @@
 
 #include <Gosu/Color.hpp>
 #include <Gosu/IO.hpp>
+#include <Gosu/Utility.hpp>
 #include <string>
 #include <vector>
 
@@ -31,14 +32,17 @@ namespace Gosu
 
         void resize(int width, int height, Color c = Color::NONE);
 
-        /// Returns the color at the specified position without any bounds checking.
-        Color get_pixel(int x, int y) const { return m_pixels[y * m_width + x]; }
+        /// Returns a reference to the pixel at the specified position without any bounds checking.
+        /// This can be a two-argument operator[] once we require C++23.
+        const Color& pixel(int x, int y) const { return m_pixels[y * m_width + x]; }
 
-        /// Sets the pixel at the specified position without any bounds checking.
-        void set_pixel(int x, int y, Color c) { m_pixels[y * m_width + x] = c; }
+        /// Returns a reference to the pixel at the specified position without any bounds checking.
+        /// This can be a two-argument operator[] once we require C++23.
+        Color& pixel(int x, int y) { return m_pixels[y * m_width + x]; }
 
         /// This updates a pixel using the "over" alpha compositing operator, see:
         /// https://en.wikipedia.org/wiki/Alpha_compositing
+        /// Like pixel(), it does not perform any bounds checking.
         void blend_pixel(int x, int y, Color c);
 
         /// Inserts a bitmap at the given position. Parts of the inserted bitmap that would be
@@ -47,8 +51,8 @@ namespace Gosu
 
         /// Inserts a portion of a bitmap at the given position. Parts of the inserted bitmap that
         /// would be outside of the target bitmap will be clipped away.
-        void insert(int x, int y, const Bitmap& source, int src_x, int src_y, int src_width,
-                    int src_height);
+        /// Parts of the source_rect that are outside of the source image will be skipped.
+        void insert(int x, int y, const Bitmap& source, Rect source_rect);
 
         /// Direct access to the array of color values.
         const Color* data() const { return m_pixels.data(); }
@@ -56,8 +60,11 @@ namespace Gosu
         /// Direct access to the array of color values.
         Color* data() { return m_pixels.data(); }
 
+        bool operator==(const Bitmap&) const = default;
+
 #ifdef FRIEND_TEST
         FRIEND_TEST(BitmapTests, memory_management);
+        FRIEND_TEST(BitmapTests, insert);
 #endif
     };
 
@@ -76,6 +83,5 @@ namespace Gosu
     /// value of these transparent pixels will be adjusted to the average of their neighbors.
     void apply_color_key(Bitmap& bitmap, Color key);
 
-    Bitmap apply_border_flags(unsigned image_flags, const Bitmap& source, int src_x, int src_y,
-                              int src_width, int src_height);
+    Bitmap apply_border_flags(unsigned image_flags, const Bitmap& source, Rect source_rect);
 }

--- a/include/Gosu/Color.hpp
+++ b/include/Gosu/Color.hpp
@@ -18,7 +18,8 @@ namespace Gosu
         Color() = default;
 
         /// Implicit conversion constructor for literals of the form 0xaarrggbb.
-        explicit(false) Color(std::uint32_t argb)
+        // NOLINTNEXTLINE: We want to allow implicit conversions.
+        Color(std::uint32_t argb)
             : red(argb >> 16),
               green(argb >> 8),
               blue(argb >> 0),

--- a/include/Gosu/Fwd.hpp
+++ b/include/Gosu/Fwd.hpp
@@ -13,6 +13,7 @@ namespace Gosu
     class ImageData;
     class Input;
     class Reader;
+    struct Rect;
     class Resource;
     class Sample;
     class Song;

--- a/include/Gosu/Gosu.hpp
+++ b/include/Gosu/Gosu.hpp
@@ -1,6 +1,6 @@
-/// \mainpage Gosu C++ Documentation
+/// \mainpage Gosu: C++ Interface Reference
 ///
-/// These pages serve as a reference on the C++ interface of Gosu. For a higher-level
+/// These pages serve as a reference for the C++ interface of Gosu. For a higher-level
 /// discussion of concepts and ideas behind the library, see the Wiki entries linked
 /// from the official website, https://www.libgosu.org/.
 

--- a/include/Gosu/Graphics.hpp
+++ b/include/Gosu/Graphics.hpp
@@ -91,8 +91,7 @@ namespace Gosu
         static void schedule_draw_op(const DrawOp& op);
 
         /// Turns a portion of a bitmap into something that can be drawn on a Graphics object.
-        static std::unique_ptr<ImageData> create_image(const Bitmap& src, unsigned src_x,
-                                                       unsigned src_y, unsigned src_width,
-                                                       unsigned src_height, unsigned image_flags);
+        static std::unique_ptr<ImageData>
+        create_image(const Bitmap& source, const Rect& source_rect, unsigned image_flags);
     };
 }

--- a/include/Gosu/Image.hpp
+++ b/include/Gosu/Image.hpp
@@ -38,7 +38,7 @@ namespace Gosu
         Image(const Bitmap& source, const Rect& source_rect, unsigned image_flags = IF_SMOOTH);
 
         /// Creates an Image from a user-supplied instance of the ImageData interface.
-        explicit Image(std::unique_ptr<ImageData>&& data);
+        explicit Image(std::unique_ptr<ImageData> data);
 
         unsigned width() const;
         unsigned height() const;

--- a/include/Gosu/Image.hpp
+++ b/include/Gosu/Image.hpp
@@ -28,15 +28,14 @@ namespace Gosu
         ///
         /// A color key of #ff00ff is automatically applied to BMP image files.
         /// For more flexibility, use the corresponding constructor that uses a Bitmap object.
-        Image(const std::string& filename, int src_x, int src_y, int src_width, int src_height,
+        Image(const std::string& filename, const Rect& source_rect,
               unsigned image_flags = IF_SMOOTH);
 
         /// Converts the given bitmap into an image.
         explicit Image(const Bitmap& source, unsigned image_flags = IF_SMOOTH);
 
         /// Converts a portion of the given bitmap into an image.
-        Image(const Bitmap& source, int src_x, int src_y, int src_width, int src_height,
-              unsigned image_flags = IF_SMOOTH);
+        Image(const Bitmap& source, const Rect& source_rect, unsigned image_flags = IF_SMOOTH);
 
         /// Creates an Image from a user-supplied instance of the ImageData interface.
         explicit Image(std::unique_ptr<ImageData>&& data);

--- a/include/Gosu/Utility.hpp
+++ b/include/Gosu/Utility.hpp
@@ -5,6 +5,12 @@
 
 namespace Gosu
 {
+    /// Converts a UTF-8 string to composed UTC-4, i.e. to a list of Unicode codepoints.
+    ///
+    /// This is not quite as good as splitting a string into graphemes. For example, the "family of
+    /// four" Emoji is actually composed of seven(!) codepoints. But because Gosu's text rendering
+    /// facilities have no support for multi-codepoint graphemes, Gosu::Font and related classes are
+    /// based on codepoints.
     std::u32string utf8_to_composed_utc4(const std::string& utf8);
 
     /// Returns true if the filename has the given extension.
@@ -17,6 +23,7 @@ namespace Gosu
     /// typically the first language in the returned array that your game supports.
     std::vector<std::string> user_languages();
 
+    /// Base class to quickly make a type non-copyable/non-movable. Same as boost::noncopyable.
     class Noncopyable
     {
     protected:

--- a/include/Gosu/Utility.hpp
+++ b/include/Gosu/Utility.hpp
@@ -37,4 +37,29 @@ namespace Gosu
         Noncopyable(Noncopyable&& other) = delete;
         Noncopyable& operator=(Noncopyable&& other) = delete;
     };
+
+    struct Rect
+    {
+        int x = 0, y = 0;
+        int width = 0, height = 0;
+
+        int right() const { return x + width - 1; }
+        int bottom() const { return y + height - 1; }
+
+        /// Returns a Rect that starts at the origin and uses T::width() and T::height() as its
+        /// extents.
+        template <typename T> static Rect covering(const T& object)
+        {
+            return Rect { .x = 0, .y = 0, .width = object.width(), .height = object.height() };
+        }
+
+        /// Makes sure that this rectangle does not exceed the bounding box.
+        /// @param adjust_x If the rectangle origin will be moved to the right by this operation,
+        ///                 then this in-out parameter will be adjusted by the same amount.
+        /// @param adjust_y If the rectangle origin will be moved down by this operation,
+        ///                 then this in-out parameter will be adjusted by the same amount.
+        void clip_to(const Gosu::Rect& bounding_box, int& adjust_x, int& adjust_y);
+
+        bool operator==(const Rect& other) const = default;
+    };
 }

--- a/src/Bitmap.cpp
+++ b/src/Bitmap.cpp
@@ -179,13 +179,13 @@ Gosu::Bitmap Gosu::apply_border_flags(unsigned image_flags, const Bitmap& source
         }
     }
     if ((image_flags & IF_TILEABLE_LEFT) == 0) {
-        for (int y = 0; y < result.width(); ++y) {
+        for (int y = 0; y < result.height(); ++y) {
             result.pixel(0, y).alpha = 0;
         }
     }
-    if ((image_flags & IF_TILEABLE_TOP) == 0) {
+    if ((image_flags & IF_TILEABLE_RIGHT) == 0) {
         const int x = result.width() - 1;
-        for (int y = 0; y < result.width(); ++y) {
+        for (int y = 0; y < result.height(); ++y) {
             result.pixel(x, y).alpha = 0;
         }
     }

--- a/src/Bitmap.cpp
+++ b/src/Bitmap.cpp
@@ -1,37 +1,38 @@
 #include <Gosu/Bitmap.hpp>
 #include <Gosu/GraphicsBase.hpp>
 #include <stdexcept> // for std::invalid_argument
-#include <utility>   // for std::swap
+#include <utility> // for std::swap
 
 Gosu::Bitmap::Bitmap(int width, int height, Gosu::Color c)
+    : m_width(width),
+      m_height(height)
 {
-    resize(width, height, c);
-}
+    if (width < 0 || height < 0) {
+        throw std::invalid_argument("Negative Gosu::Bitmap size");
+    }
 
-void Gosu::Bitmap::swap(Bitmap& other)
-{
-    std::swap(m_pixels, other.m_pixels);
-    std::swap(m_width, other.m_width);
-    std::swap(m_height, other.m_height);
+    int size = width * height;
+    if (size / width != height) {
+        throw std::invalid_argument("Gosu::Bitmap size out of bounds");
+    }
+
+    m_pixels.resize(static_cast<std::size_t>(size), c);
 }
 
 void Gosu::Bitmap::resize(int width, int height, Color c)
 {
-    if (width < 0 || height < 0) throw std::invalid_argument{"negative bitmap size"};
-
-    if (width == m_width && height == m_height) return;
-
-    Bitmap temp;
-    temp.m_width = width;
-    temp.m_height = height;
-    temp.m_pixels.resize(width * height, c);
-    temp.insert(0, 0, *this);
-    swap(temp);
+    if (width != m_width || height != m_height) {
+        Bitmap temp(width, height, c);
+        temp.insert(0, 0, *this);
+        std::swap(*this, temp);
+    }
 }
 
 void Gosu::Bitmap::blend_pixel(int x, int y, Color c)
 {
-    if (c.alpha == 0) return;
+    if (c.alpha == 0) {
+        return;
+    }
 
     Color out = get_pixel(x, y);
     if (out.alpha == 0) {
@@ -42,9 +43,9 @@ void Gosu::Bitmap::blend_pixel(int x, int y, Color c)
     int inv_alpha = out.alpha * (255 - c.alpha) / 255;
 
     out.alpha = (c.alpha + inv_alpha);
-    out.red =   ((c.red   * c.alpha + out.red   * inv_alpha) / out.alpha);
+    out.red = ((c.red * c.alpha + out.red * inv_alpha) / out.alpha);
     out.green = ((c.green * c.alpha + out.green * inv_alpha) / out.alpha);
-    out.blue =  ((c.blue  * c.alpha + out.blue  * inv_alpha) / out.alpha);
+    out.blue = ((c.blue * c.alpha + out.blue * inv_alpha) / out.alpha);
 
     set_pixel(x, y, out);
 }
@@ -54,15 +55,17 @@ void Gosu::Bitmap::insert(int x, int y, const Bitmap& source)
     insert(x, y, source, 0, 0, source.width(), source.height());
 }
 
-void Gosu::Bitmap::insert(int x, int y, const Bitmap& source,
-                          int src_x, int src_y, int src_width, int src_height)
+void Gosu::Bitmap::insert(int x, int y, const Bitmap& source, int src_x, int src_y, int src_width,
+                          int src_height)
 {
     // TODO: This should use memcpy if possible (x == 0 && src_width == this->width())
 
     if (x < 0) {
         int clip_left = -x;
 
-        if (clip_left >= src_width) return;
+        if (clip_left >= src_width) {
+            return;
+        }
 
         src_x += clip_left;
         src_width -= clip_left;
@@ -72,7 +75,9 @@ void Gosu::Bitmap::insert(int x, int y, const Bitmap& source,
     if (y < 0) {
         int clip_top = -y;
 
-        if (clip_top >= src_height) return;
+        if (clip_top >= src_height) {
+            return;
+        }
 
         src_y += clip_top;
         src_height -= clip_top;
@@ -80,13 +85,17 @@ void Gosu::Bitmap::insert(int x, int y, const Bitmap& source,
     }
 
     if (x + src_width > m_width) {
-        if (x >= m_width) return;
+        if (x >= m_width) {
+            return;
+        }
 
         src_width = m_width - x;
     }
 
     if (y + src_height > m_height) {
-        if (y >= m_height) return;
+        if (y >= m_height) {
+            return;
+        }
 
         src_height = m_height - y;
     }
@@ -106,18 +115,26 @@ void Gosu::apply_color_key(Bitmap& bitmap, Color key)
                 // Calculate the average R/G/B of adjacent, non-transparent pixels.
                 unsigned neighbors = 0, red = 0, green = 0, blue = 0;
                 auto visit = [&](Color c) {
-                  if (c != key) {
-                      neighbors += 1;
-                      red += c.red;
-                      green += c.green;
-                      blue += c.blue;
-                  }
+                    if (c != key) {
+                        neighbors += 1;
+                        red += c.red;
+                        green += c.green;
+                        blue += c.blue;
+                    }
                 };
 
-                if (x > 0) visit(bitmap.get_pixel(x - 1, y));
-                if (x < bitmap.width() - 1) visit(bitmap.get_pixel(x + 1, y));
-                if (y > 0) visit(bitmap.get_pixel(x, y - 1));
-                if (y < bitmap.height() - 1) visit(bitmap.get_pixel(x, y + 1));
+                if (x > 0) {
+                    visit(bitmap.get_pixel(x - 1, y));
+                }
+                if (x < bitmap.width() - 1) {
+                    visit(bitmap.get_pixel(x + 1, y));
+                }
+                if (y > 0) {
+                    visit(bitmap.get_pixel(x, y - 1));
+                }
+                if (y < bitmap.height() - 1) {
+                    visit(bitmap.get_pixel(x, y + 1));
+                }
 
                 Color replacement = Color::NONE;
                 if (neighbors > 0) {
@@ -131,10 +148,10 @@ void Gosu::apply_color_key(Bitmap& bitmap, Color key)
     }
 }
 
-Gosu::Bitmap Gosu::apply_border_flags(unsigned image_flags, const Bitmap& source,
-                                      int src_x, int src_y, int src_width, int src_height)
+Gosu::Bitmap Gosu::apply_border_flags(unsigned image_flags, const Bitmap& source, int src_x,
+                                      int src_y, int src_width, int src_height)
 {
-    // By default, we add one pixel of transparent data around the whole image to so that during
+    // By default, we add one pixel of transparent data around the whole image so that during
     // interpolation, the image just fades out, instead of bleeding into adjacent image data on
     // whatever shared texture atlas it ends up on.
     // However, if a border is marked as "tileable", we instead repeat the outermost pixels, which
@@ -143,49 +160,44 @@ Gosu::Bitmap Gosu::apply_border_flags(unsigned image_flags, const Bitmap& source
     // TODO: Instead of using Color::NONE (transparent black) for non-tileable image, still repeat
     // the border pixel colors, but turn them fully transparent.
 
-    // Backward compatibility: This used to be 'bool tileable'.
-    if (image_flags == 1) image_flags = IF_TILEABLE;
+    // Backward compatibility: This used to be 'bool tileable'. Make sure that anyone who still
+    // passes "true" (implicitly converted to 1) automatically gets upgraded to IF_TILEABLE.
+    if (image_flags == 1) {
+        image_flags = IF_TILEABLE;
+    }
 
-    Gosu::Bitmap dest{src_width + 2, src_height + 2};
+    Gosu::Bitmap dest(src_width + 2, src_height + 2);
 
-    // The borders are made "harder" by duplicating the original bitmap's
-    // borders.
+    // The borders are made "harder" by duplicating the original bitmap's borders.
 
     // Top.
     if (image_flags & IF_TILEABLE_TOP) {
-        dest.insert(1, 0,
-                    source, src_x, src_y, src_width, 1);
+        dest.insert(1, 0, source, src_x, src_y, src_width, 1);
     }
     // Bottom.
     if (image_flags & IF_TILEABLE_BOTTOM) {
-        dest.insert(1, dest.height() - 1,
-                    source, src_x, src_y + src_height - 1, src_width, 1);
+        dest.insert(1, dest.height() - 1, source, src_x, src_y + src_height - 1, src_width, 1);
     }
     // Left.
     if (image_flags & IF_TILEABLE_LEFT) {
-        dest.insert(0, 1,
-                    source, src_x, src_y, 1, src_height);
+        dest.insert(0, 1, source, src_x, src_y, 1, src_height);
     }
     // Right.
     if (image_flags & IF_TILEABLE_RIGHT) {
-        dest.insert(dest.width() - 1, 1,
-                    source, src_x + src_width - 1, src_y, 1, src_height);
+        dest.insert(dest.width() - 1, 1, source, src_x + src_width - 1, src_y, 1, src_height);
     }
 
     // Top left.
     if ((image_flags & IF_TILEABLE_TOP) && (image_flags & IF_TILEABLE_LEFT)) {
-        dest.set_pixel(0, 0,
-                       source.get_pixel(src_x, src_y));
+        dest.set_pixel(0, 0, source.get_pixel(src_x, src_y));
     }
     // Top right.
     if ((image_flags & IF_TILEABLE_TOP) && (image_flags & IF_TILEABLE_RIGHT)) {
-        dest.set_pixel(dest.width() - 1, 0,
-                       source.get_pixel(src_x + src_width - 1, src_y));
+        dest.set_pixel(dest.width() - 1, 0, source.get_pixel(src_x + src_width - 1, src_y));
     }
     // Bottom left.
     if ((image_flags & IF_TILEABLE_BOTTOM) && (image_flags & IF_TILEABLE_LEFT)) {
-        dest.set_pixel(0, dest.height() - 1,
-                       source.get_pixel(src_x, src_y + src_height - 1));
+        dest.set_pixel(0, dest.height() - 1, source.get_pixel(src_x, src_y + src_height - 1));
     }
     // Bottom right.
     if ((image_flags & IF_TILEABLE_BOTTOM) && (image_flags & IF_TILEABLE_RIGHT)) {
@@ -194,7 +206,6 @@ Gosu::Bitmap Gosu::apply_border_flags(unsigned image_flags, const Bitmap& source
     }
 
     // Now put the final image into the prepared borders.
-    dest.insert(1, 1,
-                source, src_x, src_y, src_width, src_height);
+    dest.insert(1, 1, source, src_x, src_y, src_width, src_height);
     return dest;
 }

--- a/src/Bitmap.cpp
+++ b/src/Bitmap.cpp
@@ -1,5 +1,6 @@
 #include <Gosu/Bitmap.hpp>
 #include <Gosu/GraphicsBase.hpp>
+#include <cstring> // for std::memcpy
 #include <stdexcept> // for std::invalid_argument
 #include <utility> // for std::swap
 
@@ -12,7 +13,7 @@ Gosu::Bitmap::Bitmap(int width, int height, Gosu::Color c)
     }
 
     int size = width * height;
-    if (size / width != height) {
+    if (width != 0 && size / width != height) {
         throw std::invalid_argument("Gosu::Bitmap size out of bounds");
     }
 
@@ -34,9 +35,9 @@ void Gosu::Bitmap::blend_pixel(int x, int y, Color c)
         return;
     }
 
-    Color out = get_pixel(x, y);
+    Color out = pixel(x, y);
     if (out.alpha == 0) {
-        set_pixel(x, y, c);
+        pixel(x, y) = c;
         return;
     }
 
@@ -47,62 +48,47 @@ void Gosu::Bitmap::blend_pixel(int x, int y, Color c)
     out.green = ((c.green * c.alpha + out.green * inv_alpha) / out.alpha);
     out.blue = ((c.blue * c.alpha + out.blue * inv_alpha) / out.alpha);
 
-    set_pixel(x, y, out);
+    pixel(x, y) = out;
 }
 
 void Gosu::Bitmap::insert(int x, int y, const Bitmap& source)
 {
-    insert(x, y, source, 0, 0, source.width(), source.height());
+    insert(x, y, source, Rect::covering(source));
 }
 
-void Gosu::Bitmap::insert(int x, int y, const Bitmap& source, int src_x, int src_y, int src_width,
-                          int src_height)
+void Gosu::Bitmap::insert(int x, int y, const Bitmap& source, Rect source_rect)
 {
-    // TODO: This should use memcpy if possible (x == 0 && src_width == this->width())
-
-    if (x < 0) {
-        int clip_left = -x;
-
-        if (clip_left >= src_width) {
-            return;
-        }
-
-        src_x += clip_left;
-        src_width -= clip_left;
-        x = 0;
+    if (&source == this) {
+        throw std::invalid_argument("Gosu::Bitmap::insert cannot copy parts of itself");
     }
 
-    if (y < 0) {
-        int clip_top = -y;
+    // Make sure that the source area does not exceed the source image.
+    // If we need to move the source_rect origin, then also move the target rectangle origin.
+    source_rect.clip_to(Rect::covering(source), x, y);
 
-        if (clip_top >= src_height) {
-            return;
-        }
+    // Set up the target area and make sure that it does not exceed this image.
+    Rect target_rect { .x = x, .y = y, .width = source_rect.width, .height = source_rect.height };
+    // If we need to move the target_rect origin, then also move the source_rect origin.
+    target_rect.clip_to(Rect::covering(*this), source_rect.x, source_rect.y);
 
-        src_y += clip_top;
-        src_height -= clip_top;
-        y = 0;
-    }
+    // These are the first source and first destination pixels/rows.
+    Color* target_ptr = &pixel(target_rect.x, target_rect.y);
+    const Color* source_ptr = &source.pixel(source_rect.x, source_rect.y);
 
-    if (x + src_width > m_width) {
-        if (x >= m_width) {
-            return;
-        }
+    // target_rect might be smaller than source_rect now, so use its width/height for copying.
 
-        src_width = m_width - x;
-    }
-
-    if (y + src_height > m_height) {
-        if (y >= m_height) {
-            return;
-        }
-
-        src_height = m_height - y;
-    }
-
-    for (int rel_y = 0; rel_y < src_height; ++rel_y) {
-        for (int rel_x = 0; rel_x < src_width; ++rel_x) {
-            set_pixel(x + rel_x, y + rel_y, source.get_pixel(src_x + rel_x, src_y + rel_y));
+    if (width() == source.width() && width() == target_rect.width) {
+        // If both images have the same width, and we want to copy full lines, then we can use a
+        // single memcpy for the whole operation. This is especially likely if we vertically resize
+        // a bitmap.
+        const int size = target_rect.width * target_rect.height;
+        std::memcpy(target_ptr, source_ptr, static_cast<std::size_t>(size) * sizeof(Color));
+    } else {
+        // Otherwise, we need to copy line by line.
+        for (int row = 0; row < target_rect.height; ++row) {
+            std::memcpy(target_ptr, source_ptr, target_rect.width * sizeof(Color));
+            target_ptr += width();
+            source_ptr += source.width();
         }
     }
 }
@@ -111,10 +97,10 @@ void Gosu::apply_color_key(Bitmap& bitmap, Color key)
 {
     for (int y = 0; y < bitmap.height(); ++y) {
         for (int x = 0; x < bitmap.width(); ++x) {
-            if (bitmap.get_pixel(x, y) == key) {
+            if (bitmap.pixel(x, y) == key) {
                 // Calculate the average R/G/B of adjacent, non-transparent pixels.
                 unsigned neighbors = 0, red = 0, green = 0, blue = 0;
-                auto visit = [&](Color c) {
+                const auto visit = [&](Color c) {
                     if (c != key) {
                         neighbors += 1;
                         red += c.red;
@@ -124,16 +110,16 @@ void Gosu::apply_color_key(Bitmap& bitmap, Color key)
                 };
 
                 if (x > 0) {
-                    visit(bitmap.get_pixel(x - 1, y));
+                    visit(bitmap.pixel(x - 1, y));
                 }
                 if (x < bitmap.width() - 1) {
-                    visit(bitmap.get_pixel(x + 1, y));
+                    visit(bitmap.pixel(x + 1, y));
                 }
                 if (y > 0) {
-                    visit(bitmap.get_pixel(x, y - 1));
+                    visit(bitmap.pixel(x, y - 1));
                 }
                 if (y < bitmap.height() - 1) {
-                    visit(bitmap.get_pixel(x, y + 1));
+                    visit(bitmap.pixel(x, y + 1));
                 }
 
                 Color replacement = Color::NONE;
@@ -142,70 +128,67 @@ void Gosu::apply_color_key(Bitmap& bitmap, Color key)
                     replacement.green = green / neighbors;
                     replacement.blue = blue / neighbors;
                 }
-                bitmap.set_pixel(x, y, replacement);
+                bitmap.pixel(x, y) = replacement;
             }
         }
     }
 }
 
-Gosu::Bitmap Gosu::apply_border_flags(unsigned image_flags, const Bitmap& source, int src_x,
-                                      int src_y, int src_width, int src_height)
+Gosu::Bitmap Gosu::apply_border_flags(unsigned image_flags, const Bitmap& source, Rect source_rect)
 {
-    // By default, we add one pixel of transparent data around the whole image so that during
-    // interpolation, the image just fades out, instead of bleeding into adjacent image data on
-    // whatever shared texture atlas it ends up on.
-    // However, if a border is marked as "tileable", we instead repeat the outermost pixels, which
-    // leads to a nice sharp/hard border with no interpolation at all.
-
-    // TODO: Instead of using Color::NONE (transparent black) for non-tileable image, still repeat
-    // the border pixel colors, but turn them fully transparent.
-
     // Backward compatibility: This used to be 'bool tileable'. Make sure that anyone who still
     // passes "true" (implicitly converted to 1) automatically gets upgraded to IF_TILEABLE.
     if (image_flags == 1) {
         image_flags = IF_TILEABLE;
     }
 
-    Gosu::Bitmap dest(src_width + 2, src_height + 2);
+    // Add one extra pixel around all four sides of the image.
+    Gosu::Bitmap result(source_rect.width + 2, source_rect.height + 2);
+    result.insert(1, 1, source, source_rect);
 
-    // The borders are made "harder" by duplicating the original bitmap's borders.
+    // Now duplicate the edges of the image on all four sides.
+    const Rect top { source_rect.x, source_rect.y, source_rect.width, 1 };
+    result.insert(1, 0, source, top);
+    const Rect bottom { source_rect.x, source_rect.bottom(), source_rect.width, 1 };
+    result.insert(1, result.height() - 1, source, bottom);
+    const Rect left { source_rect.x, source_rect.y, 1, source_rect.height };
+    result.insert(0, 1, source, left);
+    const Rect right { source_rect.right(), source_rect.y, 1, source_rect.height };
+    result.insert(result.width() - 1, 1, source, right);
+    // Also duplicate the corners of each size.
+    const Rect top_left { source_rect.x, source_rect.y, 1, 1 };
+    result.insert(0, 0, source, top_left);
+    const Rect top_right { source_rect.right(), source_rect.y, 1, 1 };
+    result.insert(result.width() - 1, 0, source, top_right);
+    const Rect bottom_left { source_rect.x, source_rect.bottom(), 1, 1 };
+    result.insert(0, result.height() - 1, source, bottom_left);
+    const Rect bottom_right { source_rect.right(), source_rect.bottom(), 1, 1 };
+    result.insert(result.width() - 1, result.height() - 1, source, bottom_right);
 
-    // Top.
-    if (image_flags & IF_TILEABLE_TOP) {
-        dest.insert(1, 0, source, src_x, src_y, src_width, 1);
+    // On edges which are supposed to have tileable borders, we are now finished.
+    // Where soft borders are desired, we need to make all pixels on a side fully transparent.
+    if ((image_flags & IF_TILEABLE_TOP) == 0) {
+        for (int x = 0; x < result.width(); ++x) {
+            result.pixel(x, 0).alpha = 0;
+        }
     }
-    // Bottom.
-    if (image_flags & IF_TILEABLE_BOTTOM) {
-        dest.insert(1, dest.height() - 1, source, src_x, src_y + src_height - 1, src_width, 1);
+    if ((image_flags & IF_TILEABLE_BOTTOM) == 0) {
+        const int y = result.height() - 1;
+        for (int x = 0; x < result.width(); ++x) {
+            result.pixel(x, y).alpha = 0;
+        }
     }
-    // Left.
-    if (image_flags & IF_TILEABLE_LEFT) {
-        dest.insert(0, 1, source, src_x, src_y, 1, src_height);
+    if ((image_flags & IF_TILEABLE_LEFT) == 0) {
+        for (int y = 0; y < result.width(); ++y) {
+            result.pixel(0, y).alpha = 0;
+        }
     }
-    // Right.
-    if (image_flags & IF_TILEABLE_RIGHT) {
-        dest.insert(dest.width() - 1, 1, source, src_x + src_width - 1, src_y, 1, src_height);
-    }
-
-    // Top left.
-    if ((image_flags & IF_TILEABLE_TOP) && (image_flags & IF_TILEABLE_LEFT)) {
-        dest.set_pixel(0, 0, source.get_pixel(src_x, src_y));
-    }
-    // Top right.
-    if ((image_flags & IF_TILEABLE_TOP) && (image_flags & IF_TILEABLE_RIGHT)) {
-        dest.set_pixel(dest.width() - 1, 0, source.get_pixel(src_x + src_width - 1, src_y));
-    }
-    // Bottom left.
-    if ((image_flags & IF_TILEABLE_BOTTOM) && (image_flags & IF_TILEABLE_LEFT)) {
-        dest.set_pixel(0, dest.height() - 1, source.get_pixel(src_x, src_y + src_height - 1));
-    }
-    // Bottom right.
-    if ((image_flags & IF_TILEABLE_BOTTOM) && (image_flags & IF_TILEABLE_RIGHT)) {
-        dest.set_pixel(dest.width() - 1, dest.height() - 1,
-                       source.get_pixel(src_x + src_width - 1, src_y + src_height - 1));
+    if ((image_flags & IF_TILEABLE_TOP) == 0) {
+        const int x = result.width() - 1;
+        for (int y = 0; y < result.width(); ++y) {
+            result.pixel(x, y).alpha = 0;
+        }
     }
 
-    // Now put the final image into the prepared borders.
-    dest.insert(1, 1, source, src_x, src_y, src_width, src_height);
-    return dest;
+    return result;
 }

--- a/src/BitmapIO.cpp
+++ b/src/BitmapIO.cpp
@@ -121,7 +121,7 @@ static void stbi_write_to_writer(void* context, void* data, int size)
 }
 
 void Gosu::save_image_file(const Gosu::Bitmap& bitmap, Gosu::Writer writer,
-                           const std::string_view& format_hint)
+                           std::string_view format_hint)
 {
     int ok;
 

--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -46,8 +46,8 @@ struct Gosu::Font::Impl : private Gosu::Noncopyable
 
             std::u32string string(1, codepoint);
             Bitmap bitmap(scaled_height, scaled_height);
-            auto required_width = ceil(Gosu::draw_text(bitmap, 0, 0, Color::WHITE, string, name,
-                                                       scaled_height, font_flags));
+            const int required_width = static_cast<int>(std::ceil(Gosu::draw_text(
+                bitmap, 0, 0, Color::WHITE, string, name, scaled_height, font_flags)));
             if (required_width > bitmap.width()) {
                 // If the character was wider than high, we need to render it again.
                 Bitmap resized_bitmap(required_width, scaled_height);
@@ -56,7 +56,8 @@ struct Gosu::Font::Impl : private Gosu::Noncopyable
                                 font_flags);
             }
 
-            *image = Image(bitmap, 0, 0, required_width, scaled_height, image_flags);
+            const Rect source_rect { 0, 0, required_width, static_cast<int>(scaled_height) };
+            *image = Image(bitmap, source_rect, image_flags);
         }
 
         return *image;

--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -50,7 +50,8 @@ struct Gosu::Font::Impl : private Gosu::Noncopyable
                                                        scaled_height, font_flags));
             if (required_width > bitmap.width()) {
                 // If the character was wider than high, we need to render it again.
-                Bitmap(required_width, scaled_height).swap(bitmap);
+                Bitmap resized_bitmap(required_width, scaled_height);
+                std::swap(resized_bitmap, bitmap);
                 Gosu::draw_text(bitmap, 0, 0, Color::WHITE, string, name, scaled_height,
                                 font_flags);
             }

--- a/src/Graphics.cpp
+++ b/src/Graphics.cpp
@@ -23,7 +23,7 @@ namespace Gosu
         Graphics& current_graphics()
         {
             if (current_graphics_pointer == nullptr) {
-                throw std::logic_error{"Gosu::Graphics can only be drawn to while rendering"};
+                throw std::logic_error { "Gosu::Graphics can only be drawn to while rendering" };
             }
             return *current_graphics_pointer;
         }
@@ -35,7 +35,7 @@ namespace Gosu
         DrawOpQueue& current_queue()
         {
             if (queues.empty()) {
-                throw std::logic_error{"There is no rendering queue for this operation"};
+                throw std::logic_error { "There is no rendering queue for this operation" };
             }
             return queues.back();
         }
@@ -94,7 +94,7 @@ struct Gosu::Graphics::Impl : private Gosu::Noncopyable
 };
 
 Gosu::Graphics::Graphics(unsigned phys_width, unsigned phys_height)
-: m_impl(new Impl)
+    : m_impl(new Impl)
 {
     m_impl->virt_width = phys_width;
     m_impl->virt_height = phys_height;
@@ -131,7 +131,7 @@ void Gosu::Graphics::set_resolution(unsigned virtual_width, unsigned virtual_hei
                                     double vertical_black_bar_height)
 {
     if (virtual_width == 0 || virtual_height == 0) {
-        throw std::invalid_argument{"Invalid virtual resolution."};
+        throw std::invalid_argument { "Invalid virtual resolution." };
     }
 
     m_impl->virt_width = virtual_width;
@@ -145,7 +145,7 @@ void Gosu::Graphics::set_resolution(unsigned virtual_width, unsigned virtual_hei
 void Gosu::Graphics::frame(const std::function<void()>& f)
 {
     if (current_graphics_pointer != nullptr) {
-        throw std::logic_error{"Cannot nest calls to Gosu::Graphics::begin()"};
+        throw std::logic_error { "Cannot nest calls to Gosu::Graphics::begin()" };
     }
 
     // Cancel all recording or whatever that might still be in progress...
@@ -157,8 +157,7 @@ void Gosu::Graphics::frame(const std::function<void()>& f)
         // This helps reduce allocations during normal operation.
         queues.clear();
         queues.swap(m_impl->warmed_up_queues);
-    }
-    else {
+    } else {
         // Create default draw-op queue.
         queues.emplace_back(QM_RENDER_TO_SCREEN);
     }
@@ -174,7 +173,9 @@ void Gosu::Graphics::frame(const std::function<void()>& f)
     f();
 
     // Cancel all intermediate queues that have not been cleaned up.
-    while (queues.size() > 1) queues.pop_back();
+    while (queues.size() > 1) {
+        queues.pop_back();
+    }
 
     flush();
 
@@ -202,8 +203,7 @@ void Gosu::Graphics::frame(const std::function<void()>& f)
     if (queues.size() == 1) {
         queues.swap(m_impl->warmed_up_queues);
         m_impl->warmed_up_queues.back().reset();
-    }
-    else {
+    } else {
         queues.clear();
     }
 }
@@ -217,11 +217,11 @@ void Gosu::Graphics::flush()
 void Gosu::Graphics::gl(const std::function<void()>& f)
 {
     if (current_queue().mode() == QM_RECORD_MACRO) {
-        throw std::logic_error{"Custom OpenGL is not allowed while creating a macro"};
+        throw std::logic_error { "Custom OpenGL is not allowed while creating a macro" };
     }
 
 #ifdef GOSU_IS_OPENGLES
-    throw std::logic_error{"Custom OpenGL ES is not supported yet"};
+    throw std::logic_error { "Custom OpenGL ES is not supported yet" };
 #else
     Graphics& cg = current_graphics();
 
@@ -238,7 +238,7 @@ void Gosu::Graphics::gl(const std::function<void()>& f)
 void Gosu::Graphics::gl(Gosu::ZPos z, const std::function<void()>& f)
 {
 #ifdef GOSU_IS_OPENGLES
-    throw std::logic_error{"Custom OpenGL ES is not supported yet"};
+    throw std::logic_error { "Custom OpenGL ES is not supported yet" };
 #else
     const auto wrapped_f = [f] {
         Graphics& cg = current_graphics();
@@ -406,65 +406,74 @@ void Gosu::Graphics::set_physical_resolution(unsigned phys_width, unsigned phys_
     m_impl->update_base_transform();
 }
 
-std::unique_ptr<Gosu::ImageData> Gosu::Graphics::create_image(const Bitmap& src, unsigned src_x,
-                                                              unsigned src_y, unsigned src_width,
-                                                              unsigned src_height, unsigned flags)
+std::unique_ptr<Gosu::ImageData>
+Gosu::Graphics::create_image(const Bitmap& source, const Rect& source_rect, unsigned flags)
 {
     static const unsigned max_size = MAX_TEXTURE_SIZE;
 
     // Backward compatibility: This used to be 'bool tileable'.
-    if (flags == 1) flags = IF_TILEABLE;
+    if (flags == 1) {
+        flags = IF_TILEABLE;
+    }
 
     bool wants_retro = (flags & IF_RETRO);
 
-    // Special case: If the texture is supposed to have hard borders, is
-    // quadratic, has a size that is at least 64 pixels but no more than max_size
-    // pixels and a power of two, create a single texture just for this image.
-    if ((flags & IF_TILEABLE) == IF_TILEABLE && src_width == src_height &&
-        (src_width & (src_width - 1)) == 0 && src_width >= 64 && src_width <= max_size) {
-        std::shared_ptr<Texture> texture{new Texture(src_width, src_height, wants_retro)};
+    // Special case: If the texture is supposed to be tileable, is quadratic, has a size that is at
+    // least 64 pixels but no more than max_size pixels and a power of two, create a single texture
+    // just for this image.
+    if ((flags & IF_TILEABLE) == IF_TILEABLE && source_rect.width == source_rect.height
+        && (source_rect.width & (source_rect.width - 1)) == 0 && source_rect.width >= 64
+        && source_rect.width <= max_size) {
+
+        std::shared_ptr<Texture> texture
+            = std::make_shared<Texture>(source_rect.width, source_rect.height, wants_retro);
         std::unique_ptr<ImageData> data;
 
-        // Use the source bitmap directly if the source area completely covers
-        // it.
-        if (src_x == 0 && src_width == src.width() && src_y == 0 && src_height == src.height()) {
-            data = texture->try_alloc(src, 0);
-        }
-        else {
-            Bitmap bmp(src_width, src_height);
-            bmp.insert(0, 0, src, src_x, src_y, src_width, src_height);
+        // Use the source bitmap directly if the source area completely covers it.
+        if (source_rect == Rect::covering(source)) {
+            data = texture->try_alloc(source, 0);
+        } else {
+            Bitmap bmp(source_rect.width, source_rect.height);
+            bmp.insert(0, 0, source, source_rect);
             data = texture->try_alloc(bmp, 0);
         }
 
-        if (!data) throw std::logic_error{"Internal texture block allocation error"};
+        if (!data) {
+            throw std::logic_error { "Internal texture block allocation error" };
+        }
         return data;
     }
 
     // Too large to fit on a single texture.
-    if (src_width > max_size - 2 || src_height > max_size - 2) {
-        Bitmap bmp(src_width, src_height);
-        bmp.insert(0, 0, src, src_x, src_y, src_width, src_height);
-        return std::unique_ptr<ImageData>{
-                new LargeImageData(bmp, max_size - 2, max_size - 2, flags)};
+    if (source_rect.width > max_size - 2 || source_rect.height > max_size - 2) {
+        Bitmap bmp(source_rect.width, source_rect.height);
+        bmp.insert(0, 0, source, source_rect);
+        return std::make_unique<LargeImageData>(bmp, max_size - 2, max_size - 2, flags);
     }
 
-    Bitmap bmp = apply_border_flags(flags, src, src_x, src_y, src_width, src_height);
+    Bitmap bmp = apply_border_flags(flags, source, source_rect);
 
     // Try to put the bitmap into one of the already allocated textures.
     for (const auto& texture : textures) {
-        if (texture->retro() != wants_retro) continue;
+        if (texture->retro() != wants_retro) {
+            continue;
+        }
 
         std::unique_ptr<ImageData> data = texture->try_alloc(bmp, 1);
-        if (data) return data;
+        if (data) {
+            return data;
+        }
     }
 
     // All textures are full: Create a new one.
 
-    std::shared_ptr<Texture> texture{new Texture(max_size, max_size, wants_retro)};
+    std::shared_ptr<Texture> texture = std::make_shared<Texture>(max_size, max_size, wants_retro);
     textures.push_back(texture);
 
-    std::unique_ptr<ImageData> data{texture->try_alloc(bmp, 1)};
-    if (!data.get()) throw std::logic_error("Internal texture block allocation error");
+    std::unique_ptr<ImageData> data = texture->try_alloc(bmp, 1);
+    if (!data) {
+        throw std::logic_error("Internal texture block allocation error");
+    }
 
     return data;
 }

--- a/src/Graphics.cpp
+++ b/src/Graphics.cpp
@@ -23,7 +23,7 @@ namespace Gosu
         Graphics& current_graphics()
         {
             if (current_graphics_pointer == nullptr) {
-                throw std::logic_error { "Gosu::Graphics can only be drawn to while rendering" };
+                throw std::logic_error{"Gosu::Graphics can only be drawn to while rendering"};
             }
             return *current_graphics_pointer;
         }
@@ -35,7 +35,7 @@ namespace Gosu
         DrawOpQueue& current_queue()
         {
             if (queues.empty()) {
-                throw std::logic_error { "There is no rendering queue for this operation" };
+                throw std::logic_error{"There is no rendering queue for this operation"};
             }
             return queues.back();
         }
@@ -94,7 +94,7 @@ struct Gosu::Graphics::Impl : private Gosu::Noncopyable
 };
 
 Gosu::Graphics::Graphics(unsigned phys_width, unsigned phys_height)
-    : m_impl(new Impl)
+: m_impl(new Impl)
 {
     m_impl->virt_width = phys_width;
     m_impl->virt_height = phys_height;
@@ -131,7 +131,7 @@ void Gosu::Graphics::set_resolution(unsigned virtual_width, unsigned virtual_hei
                                     double vertical_black_bar_height)
 {
     if (virtual_width == 0 || virtual_height == 0) {
-        throw std::invalid_argument { "Invalid virtual resolution." };
+        throw std::invalid_argument{"Invalid virtual resolution."};
     }
 
     m_impl->virt_width = virtual_width;
@@ -145,7 +145,7 @@ void Gosu::Graphics::set_resolution(unsigned virtual_width, unsigned virtual_hei
 void Gosu::Graphics::frame(const std::function<void()>& f)
 {
     if (current_graphics_pointer != nullptr) {
-        throw std::logic_error { "Cannot nest calls to Gosu::Graphics::begin()" };
+        throw std::logic_error{"Cannot nest calls to Gosu::Graphics::begin()"};
     }
 
     // Cancel all recording or whatever that might still be in progress...
@@ -157,7 +157,8 @@ void Gosu::Graphics::frame(const std::function<void()>& f)
         // This helps reduce allocations during normal operation.
         queues.clear();
         queues.swap(m_impl->warmed_up_queues);
-    } else {
+    }
+    else {
         // Create default draw-op queue.
         queues.emplace_back(QM_RENDER_TO_SCREEN);
     }
@@ -173,9 +174,7 @@ void Gosu::Graphics::frame(const std::function<void()>& f)
     f();
 
     // Cancel all intermediate queues that have not been cleaned up.
-    while (queues.size() > 1) {
-        queues.pop_back();
-    }
+    while (queues.size() > 1) queues.pop_back();
 
     flush();
 
@@ -203,7 +202,8 @@ void Gosu::Graphics::frame(const std::function<void()>& f)
     if (queues.size() == 1) {
         queues.swap(m_impl->warmed_up_queues);
         m_impl->warmed_up_queues.back().reset();
-    } else {
+    }
+    else {
         queues.clear();
     }
 }
@@ -217,11 +217,11 @@ void Gosu::Graphics::flush()
 void Gosu::Graphics::gl(const std::function<void()>& f)
 {
     if (current_queue().mode() == QM_RECORD_MACRO) {
-        throw std::logic_error { "Custom OpenGL is not allowed while creating a macro" };
+        throw std::logic_error{"Custom OpenGL is not allowed while creating a macro"};
     }
 
 #ifdef GOSU_IS_OPENGLES
-    throw std::logic_error { "Custom OpenGL ES is not supported yet" };
+    throw std::logic_error{"Custom OpenGL ES is not supported yet"};
 #else
     Graphics& cg = current_graphics();
 
@@ -238,7 +238,7 @@ void Gosu::Graphics::gl(const std::function<void()>& f)
 void Gosu::Graphics::gl(Gosu::ZPos z, const std::function<void()>& f)
 {
 #ifdef GOSU_IS_OPENGLES
-    throw std::logic_error { "Custom OpenGL ES is not supported yet" };
+    throw std::logic_error{"Custom OpenGL ES is not supported yet"};
 #else
     const auto wrapped_f = [f] {
         Graphics& cg = current_graphics();

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -8,7 +8,7 @@
 #include <stdexcept>
 
 Gosu::Image::Image()
-: m_data {EmptyImageData::instance_ptr()}
+: m_data{EmptyImageData::instance_ptr()}
 {
 }
 
@@ -17,20 +17,18 @@ Gosu::Image::Image(const std::string& filename, unsigned image_flags)
 {
 }
 
-Gosu::Image::Image(const std::string& filename, int src_x, int src_y, int src_width, int src_height,
-                   unsigned image_flags)
-: Image(load_image_file(filename), src_x, src_y, src_width, src_height, image_flags)
+Gosu::Image::Image(const std::string& filename, const Rect& source_rect, unsigned image_flags)
+: Image(load_image_file(filename), source_rect, image_flags)
 {
 }
 
 Gosu::Image::Image(const Bitmap& source, unsigned image_flags)
-: Image(source, 0, 0, source.width(), source.height(), image_flags)
+: Image(source, Rect::covering(source), image_flags)
 {
 }
 
-Gosu::Image::Image(const Bitmap& source, int src_x, int src_y, int src_width, int src_height,
-                   unsigned image_flags)
-: m_data(Graphics::create_image(source, Rect { src_x, src_y, src_width, src_height }, image_flags))
+Gosu::Image::Image(const Bitmap& source, const Rect& source_rect, unsigned image_flags)
+: m_data(Graphics::create_image(source, source_rect, image_flags))
 {
 }
 
@@ -125,8 +123,8 @@ std::vector<Gosu::Image> Gosu::load_tiles(const Bitmap& bmp, //
 
     for (int y = 0; y < tiles_y; ++y) {
         for (int x = 0; x < tiles_x; ++x) {
-            images.emplace_back(bmp, x * tile_width, y * tile_height, tile_width, tile_height,
-                                flags);
+            images.emplace_back(
+                bmp, Rect { x * tile_width, y * tile_height, tile_width, tile_height }, flags);
         }
     }
 

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -8,7 +8,7 @@
 #include <stdexcept>
 
 Gosu::Image::Image()
-: m_data{EmptyImageData::instance_ptr()}
+: m_data {EmptyImageData::instance_ptr()}
 {
 }
 
@@ -30,14 +30,16 @@ Gosu::Image::Image(const Bitmap& source, unsigned image_flags)
 
 Gosu::Image::Image(const Bitmap& source, int src_x, int src_y, int src_width, int src_height,
                    unsigned image_flags)
-: m_data{Graphics::create_image(source, src_x, src_y, src_width, src_height, image_flags)}
+: m_data(Graphics::create_image(source, Rect { src_x, src_y, src_width, src_height }, image_flags))
 {
 }
 
 Gosu::Image::Image(std::unique_ptr<ImageData>&& data)
 : m_data{data.release()}
 {
-    if (!m_data) throw std::invalid_argument("Gosu::Image cannot be initialized with nullptr");
+    if (!m_data) {
+        throw std::invalid_argument("Gosu::Image cannot be initialized with nullptr");
+    }
 }
 
 unsigned Gosu::Image::width() const

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -32,8 +32,8 @@ Gosu::Image::Image(const Bitmap& source, const Rect& source_rect, unsigned image
 {
 }
 
-Gosu::Image::Image(std::unique_ptr<ImageData>&& data)
-: m_data{data.release()}
+Gosu::Image::Image(std::unique_ptr<ImageData> data)
+: m_data(std::move(data))
 {
     if (!m_data) {
         throw std::invalid_argument("Gosu::Image cannot be initialized with nullptr");

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -602,7 +602,7 @@ bool Gosu::Input::down(Gosu::Button btn)
 
 double Gosu::Input::axis(Gosu::Button btn)
 {
-    unsigned axis_id = btn - GP_LEFT_STICK_X_AXIS;
+    unsigned axis_id = btn - static_cast<unsigned>(GP_LEFT_STICK_X_AXIS);
 
     if (axis_id >= axis_states.size()) {
         throw std::out_of_range("Invalid axis ID: " + std::to_string(btn));

--- a/src/LargeImageData.cpp
+++ b/src/LargeImageData.cpp
@@ -122,10 +122,10 @@ std::unique_ptr<Gosu::ImageData> Gosu::LargeImageData::subimage(int left, int to
                                                                 int height) const
 {
     if (left < 0 || top < 0 || left + width > m_w || top + height > m_h) {
-        throw std::invalid_argument { "subimage bounds exceed those of its parent" };
+        throw std::invalid_argument("subimage bounds exceed those of its parent");
     }
     if (width <= 0 || height <= 0) {
-        throw std::invalid_argument { "cannot create empty subimage" };
+        throw std::invalid_argument("cannot create empty subimage");
     }
 
     int sub_tiles_y = 0;

--- a/src/LargeImageData.cpp
+++ b/src/LargeImageData.cpp
@@ -19,7 +19,8 @@ Gosu::LargeImageData::LargeImageData(const Bitmap& source, int tile_width, int t
     m_tiles_x = (m_w + tile_width - 1) / tile_width;
     m_tiles_y = (m_h + tile_height - 1) / tile_height;
 
-    // When there are no tiles, set both fields to 0 to avoid entering any for () loop in this class.
+    // When there are no tiles, set both fields to 0 to avoid entering any for () loop in this
+    // class.
     if (m_tiles_x == 0 || m_tiles_y == 0) {
         m_tiles_x = m_tiles_y = 0;
     }
@@ -63,8 +64,9 @@ Gosu::LargeImageData::LargeImageData(const Bitmap& source, int tile_width, int t
                 local_flags |= (image_flags & IF_TILEABLE_BOTTOM);
             }
 
-            m_tiles.emplace_back(Graphics::create_image(source, x * tile_width, y * tile_height,
-                                                        src_width, src_height, local_flags));
+            m_tiles.emplace_back(Graphics::create_image(
+                source, Rect { x * tile_width, y * tile_height, src_width, src_height },
+                local_flags));
         }
     }
 }
@@ -120,10 +122,10 @@ std::unique_ptr<Gosu::ImageData> Gosu::LargeImageData::subimage(int left, int to
                                                                 int height) const
 {
     if (left < 0 || top < 0 || left + width > m_w || top + height > m_h) {
-        throw std::invalid_argument{"subimage bounds exceed those of its parent"};
+        throw std::invalid_argument { "subimage bounds exceed those of its parent" };
     }
     if (width <= 0 || height <= 0) {
-        throw std::invalid_argument{"cannot create empty subimage"};
+        throw std::invalid_argument { "cannot create empty subimage" };
     }
 
     int sub_tiles_y = 0;
@@ -165,7 +167,7 @@ std::unique_ptr<Gosu::ImageData> Gosu::LargeImageData::subimage(int left, int to
             int sub_bottom = std::min(image.height(), top + height - y);
 
             sub_tiles.emplace_back(
-                    image.subimage(sub_left, sub_top, sub_right - sub_left, sub_bottom - sub_top));
+                image.subimage(sub_left, sub_top, sub_right - sub_left, sub_bottom - sub_top));
 
             x += image.width();
         }
@@ -174,8 +176,7 @@ std::unique_ptr<Gosu::ImageData> Gosu::LargeImageData::subimage(int left, int to
 
     if (sub_tiles.size() == 1) {
         return std::move(sub_tiles[0]);
-    }
-    else {
+    } else {
         std::unique_ptr<LargeImageData> result(new LargeImageData());
         result->m_w = width;
         result->m_h = height;

--- a/src/Macro.cpp
+++ b/src/Macro.cpp
@@ -169,7 +169,7 @@ void Gosu::Macro::draw(double x1, double y1, Color c1, double x2, double y2, Col
 
     normalize_coordinates(x1, y1, x2, y2, x3, y3, c3, x4, y4, c4);
 
-    Gosu::Graphics::gl(z, [=] { pimpl->draw_vertex_arrays(x1, y1, x2, y2, x3, y3, x4, y4); });
+    Gosu::Graphics::gl(z, [=, this] { pimpl->draw_vertex_arrays(x1, y1, x2, y2, x3, y3, x4, y4); });
 }
 
 const Gosu::GLTexInfo* Gosu::Macro::gl_tex_info() const

--- a/src/RubyGosu.cxx
+++ b/src/RubyGosu.cxx
@@ -2926,9 +2926,8 @@ SWIGINTERN double Gosu_Font_markup_width(Gosu::Font *self,std::string const &mar
 SWIGINTERN Gosu::Image *new_Gosu_Image(VALUE source,VALUE options=0){
         Gosu::Bitmap bmp;
         Gosu::load_bitmap(bmp, source);
-        
-        int src_x = 0, src_y = 0;
-        int src_width = bmp.width(), src_height = bmp.height();
+
+        Gosu::Rect source_rect = Gosu::Rect::covering(bmp);
         unsigned flags = 0;
         
         if (options) {
@@ -2957,10 +2956,10 @@ SWIGINTERN Gosu::Image *new_Gosu_Image(VALUE source,VALUE options=0){
                                                "Array [x, y, width, height]");
                     }
                     
-                    src_x      = NUM2INT(rb_ary_entry(value, 0));
-                    src_y      = NUM2INT(rb_ary_entry(value, 1));
-                    src_width  = NUM2INT(rb_ary_entry(value, 2));
-                    src_height = NUM2INT(rb_ary_entry(value, 3));
+                    source_rect.x      = NUM2INT(rb_ary_entry(value, 0));
+                    source_rect.y      = NUM2INT(rb_ary_entry(value, 1));
+                    source_rect.width  = NUM2INT(rb_ary_entry(value, 2));
+                    source_rect.height = NUM2INT(rb_ary_entry(value, 3));
                 }
                 else {
                     static bool issued_warning = false;
@@ -2972,7 +2971,7 @@ SWIGINTERN Gosu::Image *new_Gosu_Image(VALUE source,VALUE options=0){
             }
         }
         
-        return new Gosu::Image(bmp, src_x, src_y, src_width, src_height, flags);
+        return new Gosu::Image(bmp, source_rect, flags);
     }
 SWIGINTERN void Gosu_Image_draw_as_quad(Gosu::Image *self,double x1,double y1,Gosu::Color c1,double x2,double y2,Gosu::Color c2,double x3,double y3,Gosu::Color c3,double x4,double y4,Gosu::Color c4,Gosu::ZPos z,Gosu::BlendMode mode=Gosu::BM_DEFAULT){
         self->data().draw(x1, y1, c1, x2, y2, c2, x3, y3, c3, x4, y4, c4, z, mode);
@@ -3234,7 +3233,7 @@ SWIGINTERN std::string Gosu_Image_inspect(Gosu::Image const *self,int max_width=
                 for (int x = 0; x < w; ++x) {
                     int scaled_x = x * bmp.width()  / w;
                     int scaled_y = y * bmp.height() / h;
-                    int alpha3bit = bmp.get_pixel(scaled_x, scaled_y).alpha / 32;
+                    int alpha3bit = bmp.pixel(scaled_x, scaled_y).alpha / 32;
                     str[(y + 1) * stride + (x + 1)] = " .:ioVM@"[alpha3bit];
                 }
                 str[(y + 1) * stride + (w + 2)] = '\n'; // newline after row of pixels
@@ -4356,7 +4355,7 @@ _wrap_Color_with_alpha(int argc, VALUE *argv, VALUE self) {
   }
   res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_Gosu__Color, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "Gosu::Color *","with_alpha", 1, self )); 
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "Gosu::Color const *","with_alpha", 1, self )); 
   }
   arg1 = reinterpret_cast< Gosu::Color * >(argp1);
   {
@@ -4364,7 +4363,7 @@ _wrap_Color_with_alpha(int argc, VALUE *argv, VALUE self) {
   }
   {
     try {
-      result = (arg1)->with_alpha(arg2);
+      result = ((Gosu::Color const *)arg1)->with_alpha(arg2);
     }
     catch (const std::exception& e) {
       SWIG_exception(SWIG_RuntimeError, e.what());

--- a/src/Utility.cpp
+++ b/src/Utility.cpp
@@ -33,8 +33,8 @@ std::u32string Gosu::utf8_to_composed_utc4(const std::string& utf8)
     auto options = static_cast<utf8proc_option_t>(UTF8PROC_NLF2LF | UTF8PROC_COMPOSE);
     auto new_length = utf8proc_normalize_utf32(utc4_data, utc4.length(), options);
     if (new_length < 0) {
-        throw std::runtime_error { "Could not normalize '" + utf8
-                                   + "': " + utf8proc_errmsg(new_length) };
+        throw std::runtime_error("Could not normalize '" + utf8
+                                 + "': " + utf8proc_errmsg(new_length));
     }
     utc4.resize(new_length);
 
@@ -69,7 +69,7 @@ bool Gosu::has_extension(std::string_view filename, std::string_view extension)
 
 std::vector<std::string> Gosu::user_languages()
 {
-    static const std::regex language_regex { "([a-z]{2})-([A-Z]{2})([^A-Z].*)?" };
+    static const std::regex language_regex("([a-z]{2})-([A-Z]{2})([^A-Z].*)?");
 
     std::vector<std::string> user_languages;
 

--- a/src/Utility.cpp
+++ b/src/Utility.cpp
@@ -94,8 +94,7 @@ std::vector<std::string> Gosu::user_languages()
 {
     std::vector<std::string> user_languages;
 
-    std::unique_ptr<SDL_Locale, decltype(SDL_free)*> locales { SDL_GetPreferredLocales(),
-                                                               SDL_free };
+    std::unique_ptr<SDL_Locale, decltype(SDL_free)*> locales(SDL_GetPreferredLocales(), SDL_free);
     if (!locales) {
         return user_languages;
     }

--- a/test/.clang-format
+++ b/test/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: InheritParentConfig
+NamespaceIndentation: Inner

--- a/test/BitmapTests.cpp
+++ b/test/BitmapTests.cpp
@@ -1,96 +1,132 @@
 #include <gtest/gtest.h>
+
 #include <Gosu/Bitmap.hpp>
+#include <climits>
+#include <stdexcept>
 
 namespace Gosu
 {
-    class BitmapTests : public testing::Test
-    {
-    };
 
-    static testing::AssertionResult visible_pixels_are_equal(const Bitmap& lhs, const Bitmap& rhs)
-    {
-        if (lhs.width() != rhs.width() || lhs.height() != rhs.height()) {
-            return testing::AssertionFailure() << "different sizes";
-        }
+class BitmapTests : public testing::Test
+{
+};
 
-        for (int x = 0; x < lhs.width(); ++x) {
-            for (int y = 0; y < lhs.height(); ++y) {
-                Color lhs_pixel = lhs.get_pixel(x, y);
-                Color rhs_pixel = rhs.get_pixel(x, y);
-
-                if (lhs_pixel.alpha == 0 && rhs_pixel.alpha == 0) continue;
-
-                if (lhs_pixel != rhs_pixel) {
-                    return testing::AssertionFailure() << "difference at " << x << ", " << y;
-                }
-            }
-        }
-
-        return testing::AssertionSuccess();
+inline testing::AssertionResult visible_pixels_are_equal(const Bitmap& lhs, const Bitmap& rhs)
+{
+    if (lhs.width() != rhs.width() || lhs.height() != rhs.height()) {
+        return testing::AssertionFailure() << "different sizes";
     }
 
-    TEST_F(BitmapTests, MemoryManagement)
-    {
-        Bitmap empty_bitmap;
-        ASSERT_EQ(empty_bitmap.width(), 0);
-        ASSERT_EQ(empty_bitmap.height(), 0);
-        ASSERT_EQ(empty_bitmap.m_pixels.size(), 0);
+    for (int x = 0; x < lhs.width(); ++x) {
+        for (int y = 0; y < lhs.height(); ++y) {
+            Color lhs_pixel = lhs.get_pixel(x, y);
+            Color rhs_pixel = rhs.get_pixel(x, y);
 
-        Bitmap bitmap{7, 3, Color::RED};
-        ASSERT_EQ(bitmap.width(), 7);
-        ASSERT_EQ(bitmap.height(), 3);
-        ASSERT_EQ(bitmap.m_pixels.size(), 7 * 3);
-        // Verify that everything was filled with the color constructor parameter.
-        for (int x = 0; x < bitmap.width(); ++x) {
-            for (int y = 0; y < bitmap.height(); ++y) {
+            if (lhs_pixel.alpha == 0 && rhs_pixel.alpha == 0) {
+                continue;
+            }
+
+            if (lhs_pixel != rhs_pixel) {
+                return testing::AssertionFailure() << "difference at " << x << ", " << y;
+            }
+        }
+    }
+
+    return testing::AssertionSuccess();
+}
+
+TEST_F(BitmapTests, memory_management)
+{
+    Bitmap empty_bitmap;
+    ASSERT_EQ(empty_bitmap.width(), 0);
+    ASSERT_EQ(empty_bitmap.height(), 0);
+    ASSERT_EQ(empty_bitmap.m_pixels.size(), 0);
+
+    Bitmap bitmap(7, 3, Color::RED);
+    ASSERT_EQ(bitmap.width(), 7);
+    ASSERT_EQ(bitmap.height(), 3);
+    ASSERT_EQ(bitmap.m_pixels.size(), 7 * 3);
+    // Verify that everything was filled with the color constructor parameter.
+    for (int x = 0; x < bitmap.width(); ++x) {
+        for (int y = 0; y < bitmap.height(); ++y) {
+            ASSERT_EQ(bitmap.get_pixel(x, y), Color::RED);
+        }
+    }
+
+    bitmap.resize(11, 4, Color::BLUE);
+    ASSERT_EQ(bitmap.width(), 11);
+    ASSERT_EQ(bitmap.height(), 4);
+    ASSERT_EQ(bitmap.m_pixels.size(), 11 * 4);
+    // When resizing, pixels to the right and below the original size must use the new color.
+    for (int x = 0; x < bitmap.width(); ++x) {
+        for (int y = 0; y < bitmap.height(); ++y) {
+            if (x >= 7 || y >= 3) {
+                ASSERT_EQ(bitmap.get_pixel(x, y), Color::BLUE);
+            } else {
                 ASSERT_EQ(bitmap.get_pixel(x, y), Color::RED);
             }
         }
-
-        bitmap.resize(11, 4, Color::BLUE);
-        ASSERT_EQ(bitmap.width(), 11);
-        ASSERT_EQ(bitmap.height(), 4);
-        ASSERT_EQ(bitmap.m_pixels.size(), 11 * 4);
-        // When resizing, pixels to the right and below the original size must use the new color.
-        for (int x = 0; x < bitmap.width(); ++x) {
-            for (int y = 0; y < bitmap.height(); ++y) {
-                if (x >= 7 || y >= 3) {
-                    ASSERT_EQ(bitmap.get_pixel(x, y), Color::BLUE);
-                }
-                else {
-                    ASSERT_EQ(bitmap.get_pixel(x, y), Color::RED);
-                }
-            }
-        }
-
-        bitmap.swap(empty_bitmap);
-        ASSERT_TRUE(bitmap.m_pixels.empty());
     }
 
-    TEST_F(BitmapTests, ImageFormatsWithAlphaChannel)
-    {
-        Bitmap bmp24 = load_image_file("test_image_io/alpha-bmp24.bmp");
-        Bitmap png4 = load_image_file("test_image_io/alpha-png4.png");
-        Bitmap png8 = load_image_file("test_image_io/alpha-png8.png");
+    std::swap(bitmap, empty_bitmap);
+    ASSERT_TRUE(bitmap.m_pixels.empty());
 
-        // Load one file via Gosu::IO to spice things up:
-        File file{"test_image_io/alpha-png32.png"};
-        Bitmap png32 = load_image_file(file.front_reader());
+    ASSERT_THROW(Bitmap(-5, 3), std::invalid_argument);
+    ASSERT_THROW(Bitmap(INT_MAX, INT_MAX), std::invalid_argument);
+}
 
-        // Also load one more image that we know is _not_ the same as the others to test that our
-        // comparison actually does something.
-        Bitmap not_equal = load_image_file("test_image_io/no-alpha-jpg.jpg");
+TEST_F(BitmapTests, blend_pixel)
+{
+    Bitmap bitmap(3, 3, Color::RED.with_alpha(64));
 
-        ASSERT_TRUE(visible_pixels_are_equal(bmp24, png4));
-        ASSERT_TRUE(visible_pixels_are_equal(bmp24, png8));
-        ASSERT_TRUE(visible_pixels_are_equal(bmp24, png32));
-        ASSERT_FALSE(visible_pixels_are_equal(bmp24, not_equal));
-    }
+    // Pixel gets fully replaced.
+    bitmap.blend_pixel(0, 0, Color::BLUE.with_alpha(255));
+    ASSERT_EQ(bitmap.get_pixel(0, 0), 0xff'0000ff);
 
-    TEST_F(BitmapTests, ImageFilesWithFullOpacity)
-    {
-        Bitmap jpg = load_image_file("test_image_io/no-alpha-jpg.jpg");
-        Bitmap png32 = load_image_file("test_image_io/no-alpha-png32.png");
-        ASSERT_TRUE(visible_pixels_are_equal(jpg, png32));
-    }
+    // No change, blended pixel is invisible.
+    bitmap.blend_pixel(1, 1, Color::BLUE.with_alpha(0));
+    ASSERT_EQ(bitmap.get_pixel(1, 1), 0x40'ff0000);
+
+    // Pixel is interpolated towards the new pixel based on both alpha values.
+    bitmap.blend_pixel(2, 2, Color::GREEN.with_alpha(128));
+    // Verify "Over" compositing operation: https://en.wikipedia.org/wiki/Alpha_compositing
+    // alpha = alpha_new + alpha_old * (1 - alpha_new). 64 is ~0.25, 128 is ~0.5.
+    const double alpha = (0.5 + 0.25 * (1 - 0.5));
+    // This is a pretty large "epsilon", but blend_pixel uses math on bytes, and 64 is not really
+    // a quarter of 255, so these little errors add up.
+    const double epsilon = 2;
+    ASSERT_NEAR(bitmap.get_pixel(2, 2).alpha, alpha * 255, epsilon);
+    // c = (c_new * alpha_new + c_old * alpha_old * (1 - alpha_new)) / alpha.
+    ASSERT_NEAR(bitmap.get_pixel(2, 2).red, (0 * 0.5 + 255 * 0.25 * (1 - 0.5)) / alpha, epsilon);
+    ASSERT_NEAR(bitmap.get_pixel(2, 2).green, (255 * 0.5 + 0 * 0.25 * (1 - 0.5)) / alpha, epsilon);
+    ASSERT_EQ(bitmap.get_pixel(2, 2).blue, 0);
+}
+
+TEST_F(BitmapTests, image_formats_with_alpha_channel)
+{
+    Bitmap bmp24 = load_image_file("test_image_io/alpha-bmp24.bmp");
+    Bitmap png4 = load_image_file("test_image_io/alpha-png4.png");
+    Bitmap png8 = load_image_file("test_image_io/alpha-png8.png");
+
+    // Load one file via Gosu::IO to spice things up:
+    File file { "test_image_io/alpha-png32.png" };
+    Bitmap png32 = load_image_file(file.front_reader());
+
+    // Also load one more image that we know is _not_ the same as the others to test that our
+    // comparison actually does something.
+    Bitmap not_equal = load_image_file("test_image_io/no-alpha-jpg.jpg");
+
+    ASSERT_TRUE(visible_pixels_are_equal(bmp24, png4));
+    ASSERT_TRUE(visible_pixels_are_equal(bmp24, png8));
+    ASSERT_TRUE(visible_pixels_are_equal(bmp24, png32));
+    ASSERT_FALSE(visible_pixels_are_equal(bmp24, not_equal));
+}
+
+TEST_F(BitmapTests, image_files_with_full_opacity)
+{
+    Bitmap jpg = load_image_file("test_image_io/no-alpha-jpg.jpg");
+    Bitmap png32 = load_image_file("test_image_io/no-alpha-png32.png");
+    ASSERT_TRUE(visible_pixels_are_equal(jpg, png32));
+}
+
 }

--- a/test/BitmapTests.cpp
+++ b/test/BitmapTests.cpp
@@ -1,39 +1,73 @@
 #include <gtest/gtest.h>
 
 #include <Gosu/Bitmap.hpp>
-#include <climits>
-#include <stdexcept>
+#include <climits> // for INT_MAX
+#include <random>
+#include <stdexcept> // for std::invalid_argument
 
 namespace Gosu
 {
 
 class BitmapTests : public testing::Test
 {
-};
+public:
+    static testing::AssertionResult visible_pixels_are_equal(const Bitmap& lhs, const Bitmap& rhs)
+    {
+        if (lhs.width() != rhs.width() || lhs.height() != rhs.height()) {
+            return testing::AssertionFailure() << "different sizes";
+        }
 
-inline testing::AssertionResult visible_pixels_are_equal(const Bitmap& lhs, const Bitmap& rhs)
-{
-    if (lhs.width() != rhs.width() || lhs.height() != rhs.height()) {
-        return testing::AssertionFailure() << "different sizes";
-    }
+        for (int x = 0; x < lhs.width(); ++x) {
+            for (int y = 0; y < lhs.height(); ++y) {
+                Color lhs_pixel = lhs.pixel(x, y);
+                Color rhs_pixel = rhs.pixel(x, y);
 
-    for (int x = 0; x < lhs.width(); ++x) {
-        for (int y = 0; y < lhs.height(); ++y) {
-            Color lhs_pixel = lhs.get_pixel(x, y);
-            Color rhs_pixel = rhs.get_pixel(x, y);
+                if (lhs_pixel.alpha == 0 && rhs_pixel.alpha == 0) {
+                    continue;
+                }
 
-            if (lhs_pixel.alpha == 0 && rhs_pixel.alpha == 0) {
-                continue;
-            }
-
-            if (lhs_pixel != rhs_pixel) {
-                return testing::AssertionFailure() << "difference at " << x << ", " << y;
+                if (lhs_pixel != rhs_pixel) {
+                    return testing::AssertionFailure() << "difference at " << x << ", " << y;
+                }
             }
         }
+
+        return testing::AssertionSuccess();
     }
 
-    return testing::AssertionSuccess();
-}
+    // This is a naive implementation of Bitmap::insert that can be used to verify that the
+    // optimized version behaves correctly.
+    static Bitmap insert_naively(const Bitmap& target, int x, int y, const Bitmap& source,
+                                 const Rect& source_rect)
+    {
+        Bitmap result = target;
+
+        for (int rel_y = 0; rel_y < source_rect.height; ++rel_y) {
+            for (int rel_x = 0; rel_x < source_rect.width; ++rel_x) {
+                const int target_x = x + rel_x;
+                if (target_x < 0 || target_x >= target.width()) {
+                    continue;
+                }
+                const int target_y = y + rel_y;
+                if (target_y < 0 || target_y >= target.height()) {
+                    continue;
+                }
+                const int source_x = source_rect.x + rel_x;
+                if (source_x < 0 || source_x >= source.width()) {
+                    continue;
+                }
+                const int source_y = source_rect.y + rel_y;
+                if (source_y < 0 || source_y >= source.height()) {
+                    continue;
+                }
+
+                result.pixel(target_x, target_y) = source.pixel(source_x, source_y);
+            }
+        }
+
+        return result;
+    }
+};
 
 TEST_F(BitmapTests, memory_management)
 {
@@ -49,7 +83,7 @@ TEST_F(BitmapTests, memory_management)
     // Verify that everything was filled with the color constructor parameter.
     for (int x = 0; x < bitmap.width(); ++x) {
         for (int y = 0; y < bitmap.height(); ++y) {
-            ASSERT_EQ(bitmap.get_pixel(x, y), Color::RED);
+            ASSERT_EQ(bitmap.pixel(x, y), Color::RED);
         }
     }
 
@@ -61,9 +95,9 @@ TEST_F(BitmapTests, memory_management)
     for (int x = 0; x < bitmap.width(); ++x) {
         for (int y = 0; y < bitmap.height(); ++y) {
             if (x >= 7 || y >= 3) {
-                ASSERT_EQ(bitmap.get_pixel(x, y), Color::BLUE);
+                ASSERT_EQ(bitmap.pixel(x, y), Color::BLUE);
             } else {
-                ASSERT_EQ(bitmap.get_pixel(x, y), Color::RED);
+                ASSERT_EQ(bitmap.pixel(x, y), Color::RED);
             }
         }
     }
@@ -81,25 +115,105 @@ TEST_F(BitmapTests, blend_pixel)
 
     // Pixel gets fully replaced.
     bitmap.blend_pixel(0, 0, Color::BLUE.with_alpha(255));
-    ASSERT_EQ(bitmap.get_pixel(0, 0), 0xff'0000ff);
+    ASSERT_EQ(bitmap.pixel(0, 0), 0xff'0000ff);
 
     // No change, blended pixel is invisible.
     bitmap.blend_pixel(1, 1, Color::BLUE.with_alpha(0));
-    ASSERT_EQ(bitmap.get_pixel(1, 1), 0x40'ff0000);
+    ASSERT_EQ(bitmap.pixel(1, 1), 0x40'ff0000);
 
     // Pixel is interpolated towards the new pixel based on both alpha values.
     bitmap.blend_pixel(2, 2, Color::GREEN.with_alpha(128));
     // Verify "Over" compositing operation: https://en.wikipedia.org/wiki/Alpha_compositing
     // alpha = alpha_new + alpha_old * (1 - alpha_new). 64 is ~0.25, 128 is ~0.5.
     const double alpha = (0.5 + 0.25 * (1 - 0.5));
-    // This is a pretty large "epsilon", but blend_pixel uses math on bytes, and 64 is not really
+    // This is a pretty large "epsilon", but blend_pixel uses integer math, and 64 is not really
     // a quarter of 255, so these little errors add up.
     const double epsilon = 2;
-    ASSERT_NEAR(bitmap.get_pixel(2, 2).alpha, alpha * 255, epsilon);
+    ASSERT_NEAR(bitmap.pixel(2, 2).alpha, alpha * 255, epsilon);
     // c = (c_new * alpha_new + c_old * alpha_old * (1 - alpha_new)) / alpha.
-    ASSERT_NEAR(bitmap.get_pixel(2, 2).red, (0 * 0.5 + 255 * 0.25 * (1 - 0.5)) / alpha, epsilon);
-    ASSERT_NEAR(bitmap.get_pixel(2, 2).green, (255 * 0.5 + 0 * 0.25 * (1 - 0.5)) / alpha, epsilon);
-    ASSERT_EQ(bitmap.get_pixel(2, 2).blue, 0);
+    ASSERT_NEAR(bitmap.pixel(2, 2).red, (0 * 0.5 + 255 * 0.25 * (1 - 0.5)) / alpha, epsilon);
+    ASSERT_NEAR(bitmap.pixel(2, 2).green, (255 * 0.5 + 0 * 0.25 * (1 - 0.5)) / alpha, epsilon);
+    ASSERT_EQ(bitmap.pixel(2, 2).blue, 0);
+}
+
+TEST_F(BitmapTests, insert)
+{
+    Bitmap canvas(5, 3);
+    canvas.m_pixels = {
+        0x00'000000, 0x00'000011, 0x00'000022, 0x00'000033, 0x00'000044, //
+        0x00'000055, 0x00'000066, 0x00'000077, 0x00'000088, 0x00'000099, //
+        0x00'0000aa, 0x00'0000bb, 0x00'0000cc, 0x00'0000dd, 0x00'0000ee, //
+    };
+
+    Bitmap red(3, 2);
+    red.m_pixels = {
+        0xff'ff0000, 0xff'ff0011, 0xff'ff0022, //
+        0xff'ff0033, 0xff'ff0044, 0xff'ff0055, //
+    };
+    // Overwrite 2x1 pixels in the top left corner.
+    canvas.insert(-1, -1, red);
+    // No-op: Too far up.
+    canvas.insert(-10, 0, red);
+    // No-op: Too far to the left.
+    canvas.insert(0, -10, red);
+    // No-op: Source area does not match input.
+
+    Bitmap green(4, 3);
+    green.m_pixels = {
+        0x80'00ff00, 0x80'00ff11, 0x80'00ff22, 0x80'00ff33, //
+        0x80'00ff44, 0x80'00ff55, 0x80'00ff66, 0x80'00ff77, //
+        0x80'00ff88, 0x80'00ff99, 0x80'00ffaa, 0x80'00ffbb, //
+    };
+    // Overwrite 2x2 pixels in the bottom left corner.
+    canvas.insert(3, 1, green);
+    // No-op: Too far to the right.
+    canvas.insert(5, 0, green);
+    // No-op: Too far down.
+    canvas.insert(0, 3, green);
+
+    const std::vector<Color> expected_pixels {
+        0xff'ff0044, 0xff'ff0055, 0x00'000022, 0x00'000033, 0x00'000044, //
+        0x00'000055, 0x00'000066, 0x00'000077, 0x80'00ff00, 0x80'00ff11, //
+        0x00'0000aa, 0x00'0000bb, 0x00'0000cc, 0x80'00ff44, 0x80'00ff55, //
+    };
+    ASSERT_EQ(canvas.m_pixels, expected_pixels);
+}
+
+TEST_F(BitmapTests, insert_fuzzing)
+{
+    std::random_device rd;
+    std::mt19937_64 mt(rd());
+
+    const auto next_size = [&mt] {
+        static std::uniform_int_distribution size_distribution(0, 20);
+        return size_distribution(mt);
+    };
+
+    const auto next_offset = [&mt] {
+        static std::uniform_int_distribution offset_distribution(-20, 20);
+        return offset_distribution(mt);
+    };
+
+    const auto next_color = [&mt] {
+        static std::uniform_int_distribution<std::uint64_t> color_distribution(0);
+        return color_distribution(mt);
+    };
+
+    for (int i = 0; i < 20'000; ++i) {
+        Bitmap target(next_size(), next_size());
+        std::generate_n(target.data(), target.width() * target.height(), next_color);
+
+        Bitmap source(next_size(), next_size());
+        std::generate_n(source.data(), source.width() * source.height(), next_color);
+
+        const Rect source_rect { next_offset(), next_offset(), next_size(), next_size() };
+        const int x = next_offset();
+        const int y = next_offset();
+
+        const Bitmap naive_result = insert_naively(target, x, y, source, source_rect);
+        target.insert(x, y, source, source_rect);
+        ASSERT_EQ(target, naive_result);
+    }
 }
 
 TEST_F(BitmapTests, image_formats_with_alpha_channel)

--- a/test/ColorTests.cpp
+++ b/test/ColorTests.cpp
@@ -1,58 +1,110 @@
 #include <gtest/gtest.h>
+
 #include <Gosu/Color.hpp>
+#include <sstream>
 
 namespace Gosu
 {
-    class ColorTests : public testing::Test
-    {
-    };
 
-    TEST_F(ColorTests, ColorCreation)
-    {
-        EXPECT_EQ(Color::CYAN, Color{0xff'00ffff});
-        EXPECT_EQ(Color::RED, Color(0xff, 0x00, 0x00).with_alpha(255));
-        EXPECT_EQ(Color::FUCHSIA, Color::from_hsv(300.0, 1.0, 1.0));
-        EXPECT_EQ(Color::YELLOW, Color::from_hsv(60.0, 1.0, 1.0));
-        // Double input values are be adjusted/clamped.
-        EXPECT_EQ(Color::YELLOW, Color::from_hsv(-300.0, 100.0, 255.0));
+class ColorTests : public testing::Test
+{
+};
+
+TEST_F(ColorTests, color_creation)
+{
+    // Explicit construction from RGB.
+    EXPECT_EQ(Color::RED, Color(0xff, 0x00, 0x00).with_alpha(255));
+    // Implicit construction from ARGB literal.
+    EXPECT_EQ(Color::CYAN.with_alpha(128), 0x80'00ffff);
+    // Construction from HSV.
+    EXPECT_EQ(Color::FUCHSIA, Color::from_hsv(300.0, 1.0, 1.0));
+    EXPECT_EQ(Color::YELLOW, Color::from_hsv(60.0, 1.0, 1.0));
+    // Double input values are adjusted/clamped.
+    EXPECT_EQ(Color::YELLOW, Color::from_hsv(-300.0, 100.0, 255.0));
+}
+
+TEST_F(ColorTests, hsv_with_constants)
+{
+    // Gosu offers colors constants for the three primary colors and their midpoints on the hue
+    // spectrum.
+    EXPECT_EQ(Color::RED.hue(), 0.0);
+    EXPECT_EQ(Color::YELLOW.hue(), 60.0);
+    EXPECT_EQ(Color::GREEN.hue(), 120.0);
+    EXPECT_EQ(Color::AQUA.hue(), 180.0);
+    EXPECT_EQ(Color::BLUE.hue(), 240.0);
+    EXPECT_EQ(Color::FUCHSIA.hue(), 300.0);
+
+    // All of these colors are as saturated and bright as possible.
+    for (const Color c :
+         { Color::RED, Color::YELLOW, Color::GREEN, Color::CYAN, Color::BLUE, Color::FUCHSIA }) {
+        EXPECT_EQ(c.saturation(), 1.0);
+        EXPECT_EQ(c.value(), 1.0);
     }
 
-    TEST_F(ColorTests, ColorHSV)
-    {
-        // Gosu offers colors constants for the three primary colors and their midpoints on the hue
-        // spectrum.
-        EXPECT_EQ(Color::RED.hue(), 0.0);
-        EXPECT_EQ(Color::YELLOW.hue(), 60.0);
-        EXPECT_EQ(Color::GREEN.hue(), 120.0);
-        EXPECT_EQ(Color::AQUA.hue(), 180.0);
-        EXPECT_EQ(Color::BLUE.hue(), 240.0);
-        EXPECT_EQ(Color::FUCHSIA.hue(), 300.0);
+    // The brightness (value) of the three shades of gray that Gosu offers are 0.0, ~0.5, 1.0.
+    EXPECT_EQ(Color::BLACK.value(), 0.0);
+    EXPECT_NEAR(Color::GRAY.value(), 0.5, 0.01);
+    EXPECT_EQ(Color::WHITE.value(), 1.0);
 
-        // All of these colors must be as saturated and bright as possible.
-        for (const Color c :
-             {Color::RED, Color::YELLOW, Color::GREEN, Color::CYAN, Color::BLUE, Color::FUCHSIA}) {
-            EXPECT_EQ(c.saturation(), 1.0);
-            EXPECT_EQ(c.value(), 1.0);
+    for (const Color c : { Color::NONE, Color::BLACK, Color::GRAY, Color::WHITE }) {
+        // Shades of gray do not really have a hue, but 0.0 is the fallback value.
+        EXPECT_EQ(c.hue(), 0.0);
+        // Shades of gray have no saturation.
+        EXPECT_EQ(c.saturation(), 0.0);
+    }
+}
+
+TEST_F(ColorTests, hsv_roundtrip)
+{
+    for (int r = 0; r <= 255; r += 5) {
+        for (int g = 0; g <= 255; g += 4) {
+            for (int b = 0; b <= 255; b += 3) {
+                Color color_from_rgb(r, g, b);
+
+                // This is a bit fragile. Color::set_hue cannot really do anything when called on
+                // a grayscale Color vlaue, so we need to call these setters in V-S-H order.
+                Color color_from_hsv;
+                color_from_hsv.set_value(color_from_rgb.value());
+                color_from_hsv.set_saturation(color_from_rgb.saturation());
+                color_from_hsv.set_hue(color_from_rgb.hue());
+
+                EXPECT_EQ(color_from_rgb.red, color_from_hsv.red);
+                EXPECT_EQ(color_from_rgb.green, color_from_hsv.green);
+                EXPECT_EQ(color_from_rgb.blue, color_from_hsv.blue);
+            }
         }
-
-        // The brightness (value) of the three shades of gray that Gosu offers are 0.0, ~0.5, 1.0.
-        EXPECT_EQ(Color::BLACK.value(), 0.0);
-        EXPECT_NEAR(Color::GRAY.value(), 0.5, 0.01);
-        EXPECT_EQ(Color::WHITE.value(), 1.0);
-
-        for (const Color c : {Color::NONE, Color::BLACK, Color::GRAY, Color::WHITE}) {
-            // Shades of gray do not really have a hue, but 0.0 is the fallback value.
-            EXPECT_EQ(c.hue(), 0.0);
-            // Shades of gray have no saturation.
-            EXPECT_EQ(c.saturation(), 0.0);
-        }
     }
+}
 
-    TEST_F(ColorTests, ComparisonOperators)
-    {
-        EXPECT_EQ(Color::CYAN, Color::AQUA);
-        EXPECT_NE(Color::GREEN, Color::BLACK);
-        // We order by RGBA -> BLUE must come after RED. (But this is an implementation detail.)
-        EXPECT_LT(Color::BLUE, Color::RED);
-    }
+TEST_F(ColorTests, misc_functions)
+{
+    EXPECT_EQ(0x00'785634, Color(0x12'345678).bgr());
+
+    EXPECT_EQ(0x12'785634, Color(0x12'345678).abgr());
+
+    EXPECT_EQ(0x12'345678, Color(0x12'345678).argb());
+
+    const std::uint32_t rgba = Color(0x12345678).gl();
+    const auto* components = reinterpret_cast<const std::uint8_t*>(&rgba);
+    EXPECT_EQ(components[0], 0x34);
+    EXPECT_EQ(components[1], 0x56);
+    EXPECT_EQ(components[2], 0x78);
+    EXPECT_EQ(components[3], 0x12);
+
+    EXPECT_EQ(lerp(Color::RED, Color::AQUA), Color::GRAY);
+    EXPECT_EQ(multiply(Color::RED, Color::AQUA), Color::BLACK);
+
+    std::ostringstream stream;
+    stream << Color(1, 2, 3).with_alpha(4);
+    EXPECT_EQ(stream.str(), "0x04'010203");
+}
+
+TEST_F(ColorTests, comparison)
+{
+    EXPECT_EQ(Color::CYAN, Color::AQUA);
+    EXPECT_NE(Color::GREEN, Color::BLACK);
+    // We order by RGBA -> BLUE must come after RED. (But this is an implementation detail.)
+    EXPECT_LT(Color::BLUE, Color::RED);
+}
+
 }


### PR DESCRIPTION
* Add more tests for Bitmap and Color, and improve some implementations.
* For example, Gosu::Color will now survive RGB->HSV->RGB round trips without rounding errors.
* The edges of most Gosu::Images should have slightly fewer dark artifacts.
* Align clang-format code style with WebKit. Revert over-eager conversion of () to {} for conversions.