### PR TITLE
More CMake work (goal: make CLion's coverage reporting work)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,9 @@
 # CLion files
 /.idea
 /cmake-build-debug
+/cmake-build-debug-coverage
 /cmake-build-release
+*.profraw
 
 # Files from Mac builds & CocoaPod installs
 /**/xcuserdata

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,15 +22,15 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(SDL2 REQUIRED)
 find_package(OpenGL REQUIRED)
 
-if(APPLE)
+if (APPLE)
     find_library(COCOA_LIBRARY Cocoa)
     find_library(AUDIO_TOOLBOX_LIBRARY AudioToolbox)
     find_library(CORE_TEXT_LIBRARY CoreText)
     find_library(ICONV_LIBRARY iconv)
-else()
+else ()
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(FONTCONFIG REQUIRED fontconfig)
-endif()
+endif ()
 
 
 ##############################################
@@ -40,37 +40,35 @@ file(GLOB_RECURSE C_FILES ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/*.c)
 file(GLOB HEADER_FILES ${CMAKE_CURRENT_SOURCE_DIR}/include/Gosu/*.hpp)
 file(GLOB SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 
-# Build Gosu as a shared library only for now. This also means we don't have to
-# find all of our dependencies again in cmake/GosuConfig.cmake.in, as the
-# compiled .so/.dylib file will already reference them.
-add_library(gosu SHARED ${C_FILES} ${HEADER_FILES} ${SOURCE_FILES})
+add_library(gosu ${C_FILES} ${HEADER_FILES} ${SOURCE_FILES})
+
+# Gosu uses C++20 in its public interface, so CMake projects using Gosu must support it too.
+target_compile_features(gosu PUBLIC cxx_std_20)
+
+# This is necessary so that a static libgosu.a can be used in e.g. a dynamic libgosu-ffi.so.
+set_property(TARGET gosu PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 # Ignore deprecation warnings from within Gosu while compiling Gosu itself.
-set_target_properties(gosu PROPERTIES
-        COMPILE_DEFINITIONS "GOSU_DEPRECATED=")
+target_compile_definitions(gosu PRIVATE -DGOSU_DEPRECATED=)
 
 # Compile all C++ files as Objective-C++ on macOS so that we can use ObjC APIs.
-if(APPLE)
+if (APPLE)
     set_source_files_properties(${SOURCE_FILES} PROPERTIES
             COMPILE_FLAGS "-x objective-c++")
-endif()
+endif ()
 
-target_include_directories(gosu
-    PUBLIC
+target_include_directories(gosu PUBLIC
         $<INSTALL_INTERFACE:include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
 # Use target_include_directories(... SYSTEM ...) to suppress warnings in these headers.
-target_include_directories(gosu SYSTEM
-    PRIVATE
+target_include_directories(gosu SYSTEM PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/mojoAL/AL
         ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/SDL_sound
         ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/stb
-        ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/utf8proc
-        ${SDL2_INCLUDE_DIRS})
+        ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/utf8proc)
 
-target_link_libraries(gosu
-    PRIVATE
+target_link_libraries(gosu PRIVATE
         SDL2::SDL2
         OpenGL::GL
         # Only defined on macOS
@@ -93,19 +91,15 @@ install(TARGETS gosu
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-# Copied from modern-cmake-sample, although the purpose is not clear to me.
 set_target_properties(gosu PROPERTIES EXPORT_NAME Gosu)
 
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # Export the targets to a script
 install(EXPORT gosu-targets
-        FILE
-        GosuTargets.cmake
-        NAMESPACE
-        Gosu::
-        DESTINATION
-        ${INSTALL_CONFIGDIR})
+        FILE GosuTargets.cmake
+        NAMESPACE Gosu::
+        DESTINATION ${INSTALL_CONFIGDIR})
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/cmake/GosuConfig.cmake.in
@@ -129,11 +123,11 @@ export(EXPORT gosu-targets
 add_library(Gosu::Gosu ALIAS gosu)
 
 # Only build the FFI interface, examples, and tests if this is the top-level CMake module.
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     add_subdirectory(ffi)
 
     add_subdirectory(examples)
 
     # If GoogleTest is not available as a CMake module, this is a no-op.
     add_subdirectory(test)
-endif()
+endif ()

--- a/cmake/GosuConfig.cmake.in
+++ b/cmake/GosuConfig.cmake.in
@@ -1,5 +1,5 @@
 get_filename_component(GOSU_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 
-if(NOT TARGET Gosu::Gosu)
+if (NOT TARGET Gosu::Gosu)
     include("${GOSU_CMAKE_DIR}/GosuTargets.cmake")
-endif()
+endif ()

--- a/examples/TextInput/CMakeLists.txt
+++ b/examples/TextInput/CMakeLists.txt
@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 3.22.1)
 
 project(TextInput)
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 add_executable(TextInputExample
         TextInput.cpp)
 
@@ -14,7 +11,7 @@ add_executable(TextInputExample
 get_filename_component(PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} PATH CACHE)
 set_target_properties(TextInputExample PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PARENT_DIR})
 
-if(NOT TARGET Gosu::Gosu)
+if (NOT TARGET Gosu::Gosu)
     find_package(Gosu REQUIRED)
-endif()
+endif ()
 target_link_libraries(TextInputExample Gosu::Gosu)

--- a/examples/Tutorial/CMakeLists.txt
+++ b/examples/Tutorial/CMakeLists.txt
@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 3.22.1)
 
 project(Tutorial)
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 add_executable(TutorialExample
         Tutorial.cpp)
 
@@ -14,7 +11,7 @@ add_executable(TutorialExample
 get_filename_component(PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} PATH CACHE)
 set_target_properties(TutorialExample PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PARENT_DIR})
 
-if(NOT TARGET Gosu::Gosu)
+if (NOT TARGET Gosu::Gosu)
     find_package(Gosu REQUIRED)
-endif()
+endif ()
 target_link_libraries(TutorialExample Gosu::Gosu)

--- a/src/TexChunk.cpp
+++ b/src/TexChunk.cpp
@@ -17,7 +17,7 @@ void Gosu::TexChunk::set_tex_info()
 }
 
 Gosu::TexChunk::TexChunk(std::shared_ptr<Texture> texture, int x, int y, int w, int h, int padding)
-: m_texture{move(texture)},
+: m_texture{std::move(texture)},
   m_x{x},
   m_y{y},
   m_w{w},

--- a/src/Text.cpp
+++ b/src/Text.cpp
@@ -52,7 +52,7 @@ Gosu::Bitmap Gosu::layout_markup(const std::string& markup, const std::string& f
         // Feed all formatted substrings to the TextBuilder, which will construct the result.
         // Split the input string into words, because this method implements word-wrapping.
         MarkupParser parser{font_flags, true, [&text_builder](std::vector<FormattedString> word) {
-                                text_builder.feed_word(move(word));
+                                text_builder.feed_word(std::move(word));
                             }};
         parser.parse(markup);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(GTest)
 
-if(GTest_FOUND)
+if (GTest_FOUND)
     enable_testing()
 
     file(GLOB TEST_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
@@ -16,4 +16,4 @@ if(GTest_FOUND)
     # directory as a workaround.
     set_target_properties(GosuTests PROPERTIES
             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
-endif()
+endif ()


### PR DESCRIPTION
Let's see if making Gosu non-SHARED breaks anything. The thing I don't quite understand is how the generated GosuTargets.cmake is supposed to find its dependencies.