### PR TITLE
Thread safety and TexChunk lifecycle fixes

### DIFF
--- a/src/BinPacker.cpp
+++ b/src/BinPacker.cpp
@@ -15,7 +15,7 @@ Gosu::BinPacker::BinPacker(int width, int height)
 
 std::shared_ptr<const Gosu::Rect> Gosu::BinPacker::alloc(int width, int height)
 {
-    const std::scoped_lock lock(m_mutex);
+    std::unique_lock lock(m_mutex);
 
     const Rect* best_rect = best_free_rect(width, height);
 
@@ -62,6 +62,9 @@ std::shared_ptr<const Gosu::Rect> Gosu::BinPacker::alloc(int width, int height)
     }
 
     remove_free_rect(static_cast<int>(best_rect - m_free_rects.data()));
+
+    // Release the mutex lock before calling add_free_rect to avoid a deadlock.
+    lock.unlock();
 
     if (!new_rect_below.empty()) {
         add_free_rect(new_rect_below);

--- a/src/BinPacker.cpp
+++ b/src/BinPacker.cpp
@@ -15,6 +15,8 @@ Gosu::BinPacker::BinPacker(int width, int height)
 
 std::shared_ptr<const Gosu::Rect> Gosu::BinPacker::alloc(int width, int height)
 {
+    const std::scoped_lock lock(m_mutex);
+
     const Rect* best_rect = best_free_rect(width, height);
 
     // We didn't find a single free rectangle that can fit the required size? Exit.
@@ -73,6 +75,8 @@ std::shared_ptr<const Gosu::Rect> Gosu::BinPacker::alloc(int width, int height)
 
 void Gosu::BinPacker::add_free_rect(const Rect& rect)
 {
+    const std::scoped_lock lock(m_mutex);
+
 #ifndef NDEBUG
     for (const Rect& other_free_rect : m_free_rects) {
         assert(!rect.overlaps(other_free_rect));

--- a/src/BinPacker.hpp
+++ b/src/BinPacker.hpp
@@ -22,9 +22,9 @@ namespace Gosu
     /// Moving a BinPacker instance would lead to dangling pointers.)
     class BinPacker : private Noncopyable
     {
-        int m_width, m_height;
+        const int m_width, m_height;
         std::vector<Rect> m_free_rects;
-        std::recursive_mutex m_mutex;
+        std::mutex m_mutex;
 
     public:
         BinPacker(int width, int height);

--- a/src/BinPacker.hpp
+++ b/src/BinPacker.hpp
@@ -2,6 +2,7 @@
 
 #include <Gosu/Platform.hpp>
 #include <Gosu/Utility.hpp>
+#include <mutex>
 #include <memory>
 #include <vector>
 
@@ -23,6 +24,7 @@ namespace Gosu
     {
         int m_width, m_height;
         std::vector<Rect> m_free_rects;
+        std::recursive_mutex m_mutex;
 
     public:
         BinPacker(int width, int height);

--- a/src/DrawOp.hpp
+++ b/src/DrawOp.hpp
@@ -17,7 +17,9 @@ namespace Gosu
         RenderState render_state;
         // Only valid if render_state.tex_name != NO_TEXTURE
         GLfloat top, left, bottom, right;
-        
+        // Used to keep TexChunk rectangles on shared textures alive until the end of the frame.
+        std::shared_ptr<const Rect> rect_handle;
+
         // TODO: Merge with Gosu::ArrayVertex.
         struct Vertex
         {
@@ -30,7 +32,7 @@ namespace Gosu
         
         // Number of vertices used, or: complement index of code block
         int vertices_or_block_index;
-        
+
         void perform(const DrawOp* next) const
         {
             // This should not be called on GL code ops.

--- a/src/Graphics.cpp
+++ b/src/Graphics.cpp
@@ -8,8 +8,6 @@
 #include "Macro.hpp"
 #include "OffScreenTarget.hpp"
 #include <algorithm>
-#include <cmath>
-#include <functional>
 #include <memory>
 
 namespace Gosu
@@ -25,8 +23,6 @@ namespace Gosu
             }
             return *current_graphics_pointer;
         }
-
-        std::vector<std::shared_ptr<Texture>> textures;
 
         DrawOpQueueStack queues;
 
@@ -192,8 +188,6 @@ void Gosu::Graphics::frame(const std::function<void()>& f)
         flush();
     }
 
-    glFlush();
-
     current_graphics_pointer = nullptr;
 
     // Clear leftover transforms, clip rects etc.
@@ -269,8 +263,8 @@ Gosu::Image Gosu::Graphics::render(int width, int height, const std::function<vo
     GLint prev_viewport[4];
     glGetIntegerv(GL_VIEWPORT, prev_viewport);
     glViewport(0, 0, width, height);
-    // Note the flipped vertical axis in the glOrtho call - this is so we don't have to vertically
-    // flip the texture afterwards.
+    // Note the flipped vertical axis in the glOrtho call, so we don't have to vertically
+    // flip the texture afterward.
 #ifdef GOSU_IS_OPENGLES
     glOrthof(0, width, 0, height, -1, 1); // NOLINT(readability-suspicious-call-argument)
 #else
@@ -289,7 +283,6 @@ Gosu::Image Gosu::Graphics::render(int width, int height, const std::function<vo
         f();
         queues.back().perform_draw_ops_and_code();
         queues.pop_back();
-        glFlush();
 #ifndef GOSU_IS_OPENGLES
         glPopAttrib();
 #endif

--- a/src/TexChunk.cpp
+++ b/src/TexChunk.cpp
@@ -29,6 +29,8 @@ void Gosu::TexChunk::draw(double x1, double y1, Color c1, double x2, double y2, 
     op.render_state.texture = m_texture;
     op.render_state.mode = mode;
 
+    op.rect_handle = m_rect_handle;
+
     normalize_coordinates(x1, y1, x2, y2, x3, y3, c3, x4, y4, c4);
 
     op.vertices_or_block_index = 4;

--- a/src/Texture.hpp
+++ b/src/Texture.hpp
@@ -12,7 +12,7 @@ namespace Gosu
     {
         BinPacker m_bin_packer;
         std::uint32_t m_tex_name;
-        bool m_retro;
+        const bool m_retro;
 
     public:
         Texture(int width, int height, bool retro);

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -4,6 +4,8 @@
 #if defined(GOSU_IS_WIN)
 #define NOMINMAX
 #include <windows.h>
+#elif defined(GOSU_IS_MAC)
+#include <Foundation/Foundation.h>
 #endif
 
 #include <Gosu/Gosu.hpp>
@@ -30,6 +32,12 @@ namespace Gosu
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
         static SDL_Window* window = nullptr;
         if (window == nullptr) {
+#ifdef GOSU_IS_MAC
+            if (![NSThread isMainThread]) {
+                throw std::logic_error("First use of OpenGL by Gosu must be on the main thread");
+            }
+#endif
+
             if (SDL_Init(SDL_INIT_VIDEO) < 0) {
                 throw_sdl_error("Could not initialize SDL Video");
             }
@@ -64,7 +72,8 @@ namespace Gosu
         return context;
     }
 
-    void ensure_current_context() //
+    // TODO: Maybe better to have one context per thread, all of them sharing resources?
+    void ensure_current_context()
     {
         SDL_GL_MakeCurrent(shared_window(), shared_gl_context());
     }

--- a/test/ImageTests.cpp
+++ b/test/ImageTests.cpp
@@ -77,8 +77,8 @@ TEST_F(ImageTests, delete_tex_chunk_during_rendering)
     Gosu::Image image(bitmap);
     const auto* tex_info = image.drawable().gl_tex_info();
     ASSERT_NE(tex_info, nullptr);
-    // This image will not have an image by itself. Instead, it will be allocated somewhere on a
-    // shared OpenGL texture.
+    // This image will not have a full OpenGL texture by itself. Instead, it will be allocated
+    // somewhere on a shared texture.
     ASSERT_LT(tex_info->right, 0.5);
     ASSERT_LT(tex_info->bottom, 0.5);
 


### PR DESCRIPTION
I haven't spent much time thinking about multithreading in Gosu, but Ruby's garbage collector likes to free Gosu::Images from background threads, so this PR provides a minimal hotfix. (In practice, it means that Rubystein 3D now doesn't crash anymore.)