### PR TITLE
Rename Gosu::Graphics to Gosu::Viewport, move static methods out of it

### DIFF
--- a/examples/TextInput/TextInput.cpp
+++ b/examples/TextInput/TextInput.cpp
@@ -60,8 +60,8 @@ public:
             background_color = ACTIVE_COLOR;
         }
 
-        Gosu::Graphics::draw_rect(m_x - PADDING, m_y - PADDING, width() + 2 * PADDING,
-                                  height() + 2 * PADDING, background_color, 0);
+        Gosu::draw_rect(m_x - PADDING, m_y - PADDING, width() + 2 * PADDING, height() + 2 * PADDING,
+                        background_color, 0);
 
         // Calculate the position of the caret and the selection start.
         double pos_x = m_x + m_font.text_width(text().substr(0, caret_pos()));
@@ -69,11 +69,11 @@ public:
 
         // Draw the selection background, if any; if not, sel_x and pos_x will be
         // the same value, making this rect empty and invisible.
-        Gosu::Graphics::draw_rect(sel_x, m_y, pos_x - sel_x, height(), SELECTION_COLOR, 0);
+        Gosu::draw_rect(sel_x, m_y, pos_x - sel_x, height(), SELECTION_COLOR, 0);
 
         // Draw the caret if this is the currently selected field.
         if (m_window.input().text_input() == this) {
-            Gosu::Graphics::draw_rect(pos_x, m_y, 1, height(), CARET_COLOR, 0);
+            Gosu::draw_rect(pos_x, m_y, 1, height(), CARET_COLOR, 0);
         }
 
         // Finally, draw the text itself!

--- a/ffi/Gosu.cpp
+++ b/ffi/Gosu.cpp
@@ -14,24 +14,20 @@ GOSU_FFI_API const char* Gosu_last_error(void)
 
 GOSU_FFI_API void Gosu_gl_z(double z, void function(void*), void* data)
 {
-    Gosu_translate_exceptions([=] {
-        Gosu::Graphics::gl(z, [=] { function(data); });
-    });
+    Gosu_translate_exceptions([=] { Gosu::gl(z, [=] { function(data); }); });
 }
 
 GOSU_FFI_API void Gosu_gl(void function(void*), void* data)
 {
-    Gosu_translate_exceptions([=] {
-        Gosu::Graphics::gl([=] { function(data); });
-    });
+    Gosu_translate_exceptions([=] { Gosu::gl([=] { function(data); }); });
 }
 
 GOSU_FFI_API Gosu_Image* Gosu_render(int width, int height, void function(void*), void* data,
                                      unsigned image_flags)
 {
     return Gosu_translate_exceptions([=] {
-        Gosu::Image image = Gosu::Graphics::render(width, height, [=] { function(data); },
-                                                   image_flags);
+        Gosu::Image image = Gosu::render(
+            width, height, [=] { function(data); }, image_flags);
         return new Gosu_Image{image};
     });
 }
@@ -39,16 +35,14 @@ GOSU_FFI_API Gosu_Image* Gosu_render(int width, int height, void function(void*)
 GOSU_FFI_API Gosu_Image* Gosu_record(int width, int height, void function(void*), void* data)
 {
     return Gosu_translate_exceptions([=] {
-        Gosu::Image image = Gosu::Graphics::record(width, height, [=] { function(data); });
+        Gosu::Image image = Gosu::record(width, height, [=] { function(data); });
         return new Gosu_Image{image};
     });
 }
 
 GOSU_FFI_API void Gosu_flush(void)
 {
-    Gosu_translate_exceptions([=] {
-        Gosu::Graphics::flush();
-    });
+    Gosu_translate_exceptions([=] { Gosu::flush(); });
 }
 
 GOSU_FFI_API void Gosu_transform(double m0, double m1, double m2, double m3, double m4, double m5,
@@ -59,23 +53,20 @@ GOSU_FFI_API void Gosu_transform(double m0, double m1, double m2, double m3, dou
     Gosu_translate_exceptions([=] {
         Gosu::Transform transform = {m0, m1, m2,  m3,  m4,  m5,  m6,  m7,
                                      m8, m9, m10, m11, m12, m13, m14, m15};
-        Gosu::Graphics::transform(transform, [=] { function(data); });
+        Gosu::transform(transform, [=] { function(data); });
     });
 }
 
 GOSU_FFI_API void Gosu_translate(double x, double y, void function(void*), void* data)
 {
-    Gosu_translate_exceptions([=] {
-        Gosu::Graphics::transform(Gosu::Transform::translate(x, y), [=] { function(data); });
-    });
+    Gosu_translate_exceptions([=] { Gosu::transform(Gosu::Transform::translate(x, y), [=] { function(data); }); });
 }
 
 GOSU_FFI_API void Gosu_scale(double scale_x, double scale_y, double around_x, double around_y,
                              void function(void*), void* data)
 {
     Gosu_translate_exceptions([=] {
-        Gosu::Graphics::transform(
-            Gosu::Transform::scale(scale_x, scale_y).around(around_x, around_y),
+        Gosu::transform(Gosu::Transform::scale(scale_x, scale_y).around(around_x, around_y),
             [=] { function(data); });
     });
 }
@@ -84,25 +75,21 @@ GOSU_FFI_API void Gosu_rotate(double angle, double around_x, double around_y, vo
                               void* data)
 {
     Gosu_translate_exceptions([=] {
-        Gosu::Graphics::transform(Gosu::Transform::rotate(angle).around(around_x, around_y),
-                                  [=] { function(data); });
+        Gosu::transform(Gosu::Transform::rotate(angle).around(around_x, around_y),
+                        [=] { function(data); });
     });
 }
 
 GOSU_FFI_API void Gosu_clip_to(double x, double y, double width, double height,
                                void function(void*), void* data)
 {
-    Gosu_translate_exceptions([=] {
-        Gosu::Graphics::clip_to(x, y, width, height, [=] { function(data); });
-    });
+    Gosu_translate_exceptions([=] { Gosu::clip_to(x, y, width, height, [=] { function(data); }); });
 }
 
 GOSU_FFI_API void Gosu_draw_line(double x1, double y1, unsigned c1, double x2, double y2,
                                  unsigned c2, double z, unsigned mode)
 {
-    Gosu_translate_exceptions([=] {
-        Gosu::Graphics::draw_line(x1, y1, c1, x2, y2, c2, z, static_cast<Gosu::BlendMode>(mode));
-    });
+    Gosu_translate_exceptions([=] { Gosu::draw_line(x1, y1, c1, x2, y2, c2, z, static_cast<Gosu::BlendMode>(mode)); });
 }
 
 GOSU_FFI_API void Gosu_draw_triangle(double x1, double y1, unsigned c1, double x2, double y2,
@@ -110,17 +97,15 @@ GOSU_FFI_API void Gosu_draw_triangle(double x1, double y1, unsigned c1, double x
                                      unsigned mode)
 {
     Gosu_translate_exceptions([=] {
-        Gosu::Graphics::draw_triangle(x1, y1, c1, x2, y2, c2, x3, y3, c3, z,
-                                      static_cast<Gosu::BlendMode>(mode));
+        Gosu::draw_triangle(x1, y1, c1, x2, y2, c2, x3, y3, c3, z,
+                            static_cast<Gosu::BlendMode>(mode));
     });
 }
 
 GOSU_FFI_API void Gosu_draw_rect(double x, double y, double width, double height, unsigned c,
                                  double z, unsigned mode)
 {
-    Gosu_translate_exceptions([=] {
-        Gosu::Graphics::draw_rect(x, y, width, height, c, z, static_cast<Gosu::BlendMode>(mode));
-    });
+    Gosu_translate_exceptions([=] { Gosu::draw_rect(x, y, width, height, c, z, static_cast<Gosu::BlendMode>(mode)); });
 }
 
 GOSU_FFI_API void Gosu_draw_quad(double x1, double y1, unsigned c1, double x2, double y2,
@@ -128,8 +113,8 @@ GOSU_FFI_API void Gosu_draw_quad(double x1, double y1, unsigned c1, double x2, d
                                  double y4, unsigned c4, double z, unsigned mode)
 {
     Gosu_translate_exceptions([=] {
-        Gosu::Graphics::draw_quad(x1, y1, c1, x2, y2, c2, x3, y3, c3, x4, y4, c4, z,
-                                  static_cast<Gosu::BlendMode>(mode));
+        Gosu::draw_quad(x1, y1, c1, x2, y2, c2, x3, y3, c3, x4, y4, c4, z,
+                        static_cast<Gosu::BlendMode>(mode));
     });
 }
 

--- a/ffi/Gosu.cpp
+++ b/ffi/Gosu.cpp
@@ -14,20 +14,23 @@ GOSU_FFI_API const char* Gosu_last_error(void)
 
 GOSU_FFI_API void Gosu_gl_z(double z, void function(void*), void* data)
 {
-    Gosu_translate_exceptions([=] { Gosu::gl(z, [=] { function(data); }); });
+    Gosu_translate_exceptions([=] {
+        Gosu::gl(z, [=] { function(data); });
+    });
 }
 
 GOSU_FFI_API void Gosu_gl(void function(void*), void* data)
 {
-    Gosu_translate_exceptions([=] { Gosu::gl([=] { function(data); }); });
+    Gosu_translate_exceptions([=] {
+        Gosu::gl([=] { function(data); });
+    });
 }
 
 GOSU_FFI_API Gosu_Image* Gosu_render(int width, int height, void function(void*), void* data,
                                      unsigned image_flags)
 {
     return Gosu_translate_exceptions([=] {
-        Gosu::Image image = Gosu::render(
-            width, height, [=] { function(data); }, image_flags);
+        Gosu::Image image = Gosu::render(width, height, [=] { function(data); }, image_flags);
         return new Gosu_Image{image};
     });
 }
@@ -42,7 +45,9 @@ GOSU_FFI_API Gosu_Image* Gosu_record(int width, int height, void function(void*)
 
 GOSU_FFI_API void Gosu_flush(void)
 {
-    Gosu_translate_exceptions([=] { Gosu::flush(); });
+    Gosu_translate_exceptions([=] {
+        Gosu::flush();
+    });
 }
 
 GOSU_FFI_API void Gosu_transform(double m0, double m1, double m2, double m3, double m4, double m5,
@@ -59,7 +64,9 @@ GOSU_FFI_API void Gosu_transform(double m0, double m1, double m2, double m3, dou
 
 GOSU_FFI_API void Gosu_translate(double x, double y, void function(void*), void* data)
 {
-    Gosu_translate_exceptions([=] { Gosu::transform(Gosu::Transform::translate(x, y), [=] { function(data); }); });
+    Gosu_translate_exceptions([=] {
+        Gosu::transform(Gosu::Transform::translate(x, y), [=] { function(data); });
+    });
 }
 
 GOSU_FFI_API void Gosu_scale(double scale_x, double scale_y, double around_x, double around_y,
@@ -83,13 +90,17 @@ GOSU_FFI_API void Gosu_rotate(double angle, double around_x, double around_y, vo
 GOSU_FFI_API void Gosu_clip_to(double x, double y, double width, double height,
                                void function(void*), void* data)
 {
-    Gosu_translate_exceptions([=] { Gosu::clip_to(x, y, width, height, [=] { function(data); }); });
+    Gosu_translate_exceptions([=] {
+        Gosu::clip_to(x, y, width, height, [=] { function(data); });
+    });
 }
 
 GOSU_FFI_API void Gosu_draw_line(double x1, double y1, unsigned c1, double x2, double y2,
                                  unsigned c2, double z, unsigned mode)
 {
-    Gosu_translate_exceptions([=] { Gosu::draw_line(x1, y1, c1, x2, y2, c2, z, static_cast<Gosu::BlendMode>(mode)); });
+    Gosu_translate_exceptions([=] {
+        Gosu::draw_line(x1, y1, c1, x2, y2, c2, z, static_cast<Gosu::BlendMode>(mode));
+    });
 }
 
 GOSU_FFI_API void Gosu_draw_triangle(double x1, double y1, unsigned c1, double x2, double y2,
@@ -105,7 +116,9 @@ GOSU_FFI_API void Gosu_draw_triangle(double x1, double y1, unsigned c1, double x
 GOSU_FFI_API void Gosu_draw_rect(double x, double y, double width, double height, unsigned c,
                                  double z, unsigned mode)
 {
-    Gosu_translate_exceptions([=] { Gosu::draw_rect(x, y, width, height, c, z, static_cast<Gosu::BlendMode>(mode)); });
+    Gosu_translate_exceptions([=] {
+        Gosu::draw_rect(x, y, width, height, c, z, static_cast<Gosu::BlendMode>(mode));
+    });
 }
 
 GOSU_FFI_API void Gosu_draw_quad(double x1, double y1, unsigned c1, double x2, double y2,

--- a/include/Gosu/Fwd.hpp
+++ b/include/Gosu/Fwd.hpp
@@ -7,7 +7,6 @@ namespace Gosu
     class Channel;
     struct Color;
     class Font;
-    class Graphics;
     class Image;
     class Drawable;
     class Input;
@@ -16,5 +15,6 @@ namespace Gosu
     class Song;
     class TextInput;
     struct Transform;
+    class Viewport;
     class Window;
 }

--- a/include/Gosu/Graphics.hpp
+++ b/include/Gosu/Graphics.hpp
@@ -9,18 +9,15 @@
 
 namespace Gosu
 {
-    struct DrawOp;
-
-    /// Serves as the target of all drawing and provides primitive drawing functionality.
-    /// Usually created internally by Gosu::Window.
-    class Graphics : private Noncopyable
+    /// Serves as the target of all drawing. Usually created internally by Gosu::Window.
+    class Viewport : private Noncopyable
     {
         struct Impl;
         std::unique_ptr<Impl> m_impl;
 
     public:
-        Graphics(int physical_width, int physical_height);
-        ~Graphics();
+        Viewport(int physical_width, int physical_height);
+        ~Viewport();
 
         void set_resolution(int logical_width, int logical_height, //
                             double black_bar_width = 0, double black_bar_height = 0);
@@ -32,60 +29,60 @@ namespace Gosu
         /// Nothing must be drawn outside of frame() and record().
         void frame(const std::function<void()>& f);
 
-        /// Flushes the Z queue to the screen and starts a new one.
-        /// This can be useful to separate the Z queues of two parts of the game, e.g. the two
-        /// halves of a game that runs in split-screen mode.
-        static void flush();
-
-        /// Finishes all pending Gosu drawing operations and executes the code in f in a clean
-        /// OpenGL environment.
-        static void gl(const std::function<void()>& f);
-
-        /// Schedules a custom GL functor to be executed at a certain Z level.
-        /// The functor f is run in a clean GL context.
-        /// Note: You may not call any Gosu rendering functions from within the functor.
-        static void gl(ZPos z, const std::function<void()>& f);
-
-        /// Renders everything drawn in f clipped to a rectangle on the screen.
-        static void clip_to(double x, double y, double width, double height,
-                            const std::function<void()>& f);
-
-        /// Renders everything drawn in f onto a new Image of size (width, height).
-        /// @param image_flags Pass Gosu::IF_RETRO if you do not want the resulting image to use
-        /// interpolation when it is scaled or rotated.
-        static Gosu::Image render(int width, int height, const std::function<void()>& f,
-                                  unsigned image_flags = 0);
-
-        /// Records a macro and returns it as an Image.
-        static Gosu::Image record(int width, int height, const std::function<void()>& f);
-
-        /// Pushes one transformation onto the transformation stack.
-        static void transform(const Transform& transform, const std::function<void()>& f);
-
-        /// Draws a line from one point to another (last pixel exclusive).
-        /// Note: OpenGL lines are not reliable at all and may have a missing pixel at the start
-        /// or end point. Please only use this for debugging purposes. Otherwise, use a quad or
-        /// image to simulate lines, or contribute a better draw_line to Gosu.
-        static void draw_line(double x1, double y1, Color c1, double x2, double y2, Color c2,
-                              ZPos z, BlendMode mode = BM_DEFAULT);
-
-        static void draw_triangle(double x1, double y1, Color c1, //
-                                  double x2, double y2, Color c2, //
-                                  double x3, double y3, Color c3, //
-                                  ZPos z, BlendMode mode = BM_DEFAULT);
-
-        static void draw_quad(double x1, double y1, Color c1, double x2, double y2, Color c2,
-                              double x3, double y3, Color c3, double x4, double y4, Color c4,
-                              ZPos z, BlendMode mode = BM_DEFAULT);
-
-        static void draw_rect(double x, double y, double width, double height, Color c, ZPos z,
-                              BlendMode mode = BM_DEFAULT);
-
         /// For internal use only.
         void set_physical_resolution(int physical_width, int physical_height);
 
-        /// For internal use only.
-        static void schedule_draw_op(const DrawOp& op);
-
+        friend void gl(const std::function<void()>&);
+        friend void gl(ZPos, const std::function<void()>&);
+        friend void clip_to(double, double, double, double, const std::function<void()>&);
     };
+
+    /// Flushes the Z queue to the screen and starts a new one.
+    /// This can be useful to separate the Z queues of two parts of the game, e.g. the two
+    /// halves of a game that runs in split-screen mode.
+    void flush();
+
+    /// Finishes all pending Gosu drawing operations and executes the code in f in a clean
+    /// OpenGL environment.
+    void gl(const std::function<void()>& f);
+
+    /// Schedules a custom GL functor to be executed at a certain Z level.
+    /// The functor f is run in a clean GL context.
+    /// Note: You may not call any Gosu rendering functions from within the functor.
+    void gl(ZPos z, const std::function<void()>& f);
+
+    /// Renders everything drawn in f clipped to a rectangle on the screen.
+    void clip_to(double x, double y, double width, double height, const std::function<void()>& f);
+
+    /// Renders everything drawn in f onto a new Image of size (width, height).
+    /// @param image_flags Pass Gosu::IF_RETRO if you do not want the resulting image to use
+    /// interpolation when it is scaled or rotated.
+    Gosu::Image render(int width, int height, const std::function<void()>& f,
+                       unsigned image_flags = 0);
+
+    /// Records a macro and returns it as an Image.
+    Gosu::Image record(int width, int height, const std::function<void()>& f);
+
+    /// Pushes one transformation onto the transformation stack.
+    void transform(const Transform& transform, const std::function<void()>& f);
+
+    /// Draws a line from one point to another (last pixel exclusive).
+    /// Note: OpenGL lines are not reliable at all and may have a missing pixel at the start
+    /// or end point. Please only use this for debugging purposes. Otherwise, use a quad or
+    /// image to simulate lines, or contribute a better draw_line to Gosu.
+    void draw_line(double x1, double y1, Color c1, double x2, double y2, Color c2, ZPos z,
+                   BlendMode mode = BM_DEFAULT);
+
+    void draw_triangle(double x1, double y1, Color c1, //
+                       double x2, double y2, Color c2, //
+                       double x3, double y3, Color c3, //
+                       ZPos z, BlendMode mode = BM_DEFAULT);
+
+    void draw_quad(double x1, double y1, Color c1, double x2, double y2, Color c2, double x3,
+                   double y3, Color c3, double x4, double y4, Color c4, ZPos z,
+                   BlendMode mode = BM_DEFAULT);
+
+    void draw_rect(double x, double y, double width, double height, Color c, ZPos z,
+                   BlendMode mode = BM_DEFAULT);
+
 }

--- a/include/Gosu/Window.hpp
+++ b/include/Gosu/Window.hpp
@@ -132,8 +132,8 @@ namespace Gosu
         virtual void touch_ended(Touch touch) {}
         virtual void touch_cancelled(Touch touch) {}
 
-        const Graphics& graphics() const;
-        Graphics& graphics();
+        const Viewport& viewport() const;
+        Viewport& viewport();
 
         const Input& input() const;
         Input& input();

--- a/src/GosuViewController.cpp
+++ b/src/GosuViewController.cpp
@@ -172,7 +172,7 @@ static void handle_audio_interruption(void* unused, UInt32 inInterruptionState)
     
     if (window.needs_redraw()) {
         [(GosuGLView*)self.view redrawGL:^{
-            window.graphics().frame([&window] {
+            window.viewport().frame([&window] {
                 window.draw();
                 Gosu::register_frame();
             });

--- a/src/GraphicsImpl.hpp
+++ b/src/GraphicsImpl.hpp
@@ -69,6 +69,8 @@ namespace Gosu
         }
     }
 
+    void schedule_draw_op(const DrawOp& op);
+
 #ifdef GOSU_IS_IPHONE
     int clip_rect_base_factor();
 #else

--- a/src/Macro.cpp
+++ b/src/Macro.cpp
@@ -169,7 +169,7 @@ void Gosu::Macro::draw(double x1, double y1, Color c1, double x2, double y2, Col
 
     normalize_coordinates(x1, y1, x2, y2, x3, y3, c3, x4, y4, c4);
 
-    Gosu::Graphics::gl(z, [=, this] { pimpl->draw_vertex_arrays(x1, y1, x2, y2, x3, y3, x4, y4); });
+    Gosu::gl(z, [=, this] { pimpl->draw_vertex_arrays(x1, y1, x2, y2, x3, y3, x4, y4); });
 }
 
 const Gosu::GLTexInfo* Gosu::Macro::gl_tex_info() const
@@ -184,7 +184,7 @@ Gosu::Bitmap Gosu::Macro::to_bitmap() const
              pimpl->width, pimpl->height, Color::WHITE, 0, BM_DEFAULT);
     };
 
-    return Gosu::Graphics::render(pimpl->width, pimpl->height, render_this).drawable().to_bitmap();
+    return Gosu::render(pimpl->width, pimpl->height, render_this).drawable().to_bitmap();
 }
 
 std::unique_ptr<Gosu::Drawable> Gosu::Macro::subimage(const Rect&) const

--- a/src/TexChunk.cpp
+++ b/src/TexChunk.cpp
@@ -50,7 +50,7 @@ void Gosu::TexChunk::draw(double x1, double y1, Color c1, double x2, double y2, 
     op.bottom = m_info.bottom;
 
     op.z = z;
-    Graphics::schedule_draw_op(op);
+    schedule_draw_op(op);
 }
 
 std::unique_ptr<Gosu::Drawable> Gosu::TexChunk::subimage(const Rect& rect) const

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -30,7 +30,7 @@ struct Gosu::Window::Impl : private Gosu::Noncopyable
     } state
         = CLOSED;
 
-    std::unique_ptr<Graphics> graphics;
+    std::unique_ptr<Viewport> viewport;
     std::unique_ptr<Input> input;
 };
 
@@ -65,12 +65,12 @@ Gosu::Window::~Window()
 
 int Gosu::Window::width() const
 {
-    return graphics().width();
+    return viewport().width();
 }
 
 int Gosu::Window::height() const
 {
-    return graphics().height();
+    return viewport().height();
 }
 
 bool Gosu::Window::fullscreen() const
@@ -135,13 +135,13 @@ void Gosu::Window::resize(int width, int height, bool fullscreen)
 
     SDL_GL_GetDrawableSize(sdl_window(), &actual_width, &actual_height);
 
-    if (!m_impl->graphics) {
-        m_impl->graphics = std::make_unique<Graphics>(actual_width, actual_height);
+    if (!m_impl->viewport) {
+        m_impl->viewport = std::make_unique<Viewport>(actual_width, actual_height);
     }
     else {
-        m_impl->graphics->set_physical_resolution(actual_width, actual_height);
+        m_impl->viewport->set_physical_resolution(actual_width, actual_height);
     }
-    m_impl->graphics->set_resolution(width, height, black_bar_width, black_bar_height);
+    m_impl->viewport->set_resolution(width, height, black_bar_width, black_bar_height);
 
     if (!m_impl->input) {
         m_impl->input = std::make_unique<Input>(sdl_window());
@@ -261,7 +261,7 @@ bool Gosu::Window::tick()
         // Fixes https://github.com/gosu/gosu/issues/318
         int width, height;
         SDL_GL_GetDrawableSize(sdl_window(), &width, &height);
-        graphics().set_physical_resolution(width, height);
+        viewport().set_physical_resolution(width, height);
     }
 
     SDL_Event e;
@@ -321,7 +321,7 @@ bool Gosu::Window::tick()
 
     if (needs_redraw()) {
         const OpenGLContext current_context;
-        graphics().frame([&] {
+        viewport().frame([&] {
             draw();
             register_frame();
         });
@@ -371,14 +371,14 @@ void Gosu::Window::button_down(Button button)
     }
 }
 
-const Gosu::Graphics& Gosu::Window::graphics() const
+const Gosu::Viewport& Gosu::Window::viewport() const
 {
-    return *m_impl->graphics;
+    return *m_impl->viewport;
 }
 
-Gosu::Graphics& Gosu::Window::graphics()
+Gosu::Viewport& Gosu::Window::viewport()
 {
-    return *m_impl->graphics;
+    return *m_impl->viewport;
 }
 
 const Gosu::Input& Gosu::Window::input() const

--- a/src/WindowUIKit.cpp
+++ b/src/WindowUIKit.cpp
@@ -8,7 +8,7 @@ struct Gosu::Window::Impl : private Gosu::Noncopyable
 {
     UIWindow* window;
     GosuViewController* controller;
-    std::unique_ptr<Graphics> graphics;
+    std::unique_ptr<Viewport> viewport;
     std::unique_ptr<Input> input;
 
     double update_interval;
@@ -23,11 +23,11 @@ Gosu::Window::Window(int width, int height, unsigned window_flags, double update
     m_impl->controller.gosuWindow = this;
     m_impl->window.rootViewController = m_impl->controller;
 
-    // It is important to (implicitly) load the view before creating the Graphics instance.
+    // It is important to (implicitly) load the view before creating the Viewport instance.
     [m_impl->controller view];
 
-    m_impl->graphics.reset(new Graphics(screen_width(), screen_height()));
-    m_impl->graphics->set_resolution(width, height);
+    m_impl->viewport = std::make_unique<Viewport>(screen_width(), screen_height());
+    m_impl->viewport->set_resolution(width, height);
 
     m_impl->input.reset(new Input((__bridge void*) m_impl->controller.view, update_interval));
     m_impl->input->set_mouse_factors(1.0 * width / available_width(),
@@ -48,12 +48,12 @@ Gosu::Window::~Window() = default;
 
 int Gosu::Window::width() const
 {
-    return graphics().width();
+    return viewport().width();
 }
 
 int Gosu::Window::height() const
 {
-    return graphics().height();
+    return viewport().height();
 }
 
 bool Gosu::Window::fullscreen() const
@@ -104,14 +104,14 @@ void Gosu::Window::set_caption(const std::string& caption)
     m_impl->caption = caption;
 }
 
-const Gosu::Graphics& Gosu::Window::graphics() const
+const Gosu::Viewport& Gosu::Window::viewport() const
 {
-    return *m_impl->graphics;
+    return *m_impl->viewport;
 }
 
-Gosu::Graphics& Gosu::Window::graphics()
+Gosu::Viewport& Gosu::Window::viewport()
 {
-    return *m_impl->graphics;
+    return *m_impl->viewport;
 }
 
 const Gosu::Input& Gosu::Window::input() const

--- a/test/DrawableTests.cpp
+++ b/test/DrawableTests.cpp
@@ -85,10 +85,10 @@ TEST_F(DrawableTests, large_texture_allocation)
     auto tiled_drawable
         = Gosu::create_drawable(red, Gosu::Rect::covering(red), Gosu::IF_TILEABLE_TOP);
 
-    const Gosu::Image render_result = Gosu::Graphics::render(100, 100, [&] {
+    const Gosu::Image render_result = Gosu::render(100, 100, [&] {
         // Scale this image by factor 10 so that we can verify that it has a tileable top (only).
-        Gosu::Graphics::transform(Gosu::Transform::scale(10),
-                                  [&] { Gosu::Image(std::move(tiled_drawable)).draw(0, 0, 0); });
+        Gosu::transform(Gosu::Transform::scale(10),
+                        [&] { Gosu::Image(std::move(tiled_drawable)).draw(0, 0, 0); });
     });
     const Gosu::Bitmap rendered_bitmap = render_result.drawable().to_bitmap();
     for (int x = 0; x < 100; ++x) {

--- a/test/ImageTests.cpp
+++ b/test/ImageTests.cpp
@@ -36,8 +36,8 @@ TEST_F(ImageTests, render_after_color_key)
     // Turn it into an image for rendering. (Use 'true' to test a backward compatibility code path.)
     Gosu::Image image(Gosu::create_drawable(bitmap, Gosu::Rect::covering(bitmap), true));
 
-    const Gosu::Image result = Gosu::Graphics::render(300, 300, [&] {
-        Gosu::Graphics::draw_rect(0, 0, 300, 300, Gosu::Color::YELLOW, 0);
+    const Gosu::Image result = Gosu::render(300, 300, [&] {
+        Gosu::draw_rect(0, 0, 300, 300, Gosu::Color::YELLOW, 0);
         image.draw(0, 0, 1, 100, 100);
     });
 
@@ -63,7 +63,7 @@ TEST_F(ImageTests, delete_texture_during_rendering)
     ASSERT_EQ(tex_info->right, 1.0);
     ASSERT_EQ(tex_info->bottom, 1.0);
 
-    const Gosu::Image result = Gosu::Graphics::render(64, 64, [&] {
+    const Gosu::Image result = Gosu::render(64, 64, [&] {
         image.draw(0, 0, 0);
         // Reset our reference to the texture. Gosu must keep the OpenGL texture alive regardless.
         image = Gosu::Image();
@@ -82,7 +82,7 @@ TEST_F(ImageTests, delete_tex_chunk_during_rendering)
     ASSERT_LT(tex_info->right, 0.5);
     ASSERT_LT(tex_info->bottom, 0.5);
 
-    const Gosu::Image result = Gosu::Graphics::render(50, 50, [&] {
+    const Gosu::Image result = Gosu::render(50, 50, [&] {
         image.draw(0, 0, 0);
         // Now reset our image and create another image of the same size. If Gosu is not careful and
         // re-allocates another bitmap on the same part of the texture, then this will influence the

--- a/test/TiledDrawableTests.cpp
+++ b/test/TiledDrawableTests.cpp
@@ -51,7 +51,7 @@ TEST_F(TiledDrawableTests, direct_creation)
 TEST_F(TiledDrawableTests, drawing)
 {
     const auto rotated_by_90_degrees = [](const Gosu::Image& image) {
-        return Gosu::Graphics::render(image.height(), image.width(), [&] {
+        return Gosu::render(image.height(), image.width(), [&] {
             // Draw the image rotated clockwise by 90°, rotated around the bottom left corner.
             image.draw_rot(0, 0, 0, 90, 0.0, 1.0);
         });


### PR DESCRIPTION
This brings C++ Gosu more in line with Ruby/Gosu.