### PR TITLE
Rework OpenGL context handling

### DIFF
--- a/src/GosuGLView.cpp
+++ b/src/GosuGLView.cpp
@@ -23,6 +23,11 @@ namespace Gosu
 
         [EAGLContext setCurrentContext:globalContext];
     }
+
+    OpenGLContext::~OpenGLContext()
+    {
+        // Don't bother unsetting anything.
+    }
     
     int clip_rect_base_factor()
     {

--- a/src/Graphics.cpp
+++ b/src/Graphics.cpp
@@ -161,7 +161,7 @@ void Gosu::Viewport::frame(const std::function<void()>& f)
 
     queues.back().set_base_transform(m_impl->base_transform);
 
-    const OpenGLContext current_context;
+    const OpenGLContext current_context(true);
 
     glClearColor(0, 0, 0, 1);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);

--- a/src/OpenGLContext.cpp
+++ b/src/OpenGLContext.cpp
@@ -16,18 +16,16 @@ namespace
     }
 
     /// Groups the global SDL variables into a single struct so that they all either exist, or not.
-    struct SDLWindowAndGLContexts : Gosu::Noncopyable
+    struct SDLWindowAndGLContext : Gosu::Noncopyable
     {
-        /// The ID of the thread that created the window. We assume that this is the main thread on
-        /// which rendering will happen, and it receives its own OpenGL context.
-        std::thread::id main_thread;
         SDL_Window* window;
-        SDL_GLContext main_thread_context;
-        /// OpenGL context for all threads except main_thread. Multiple threads creating and
-        /// deleting images, for example, will receive serialized access to this context.
-        SDL_GLContext background_threads_context;
+        /// We only use one OpenGL context, even from background threads. It would be possible to
+        /// set up shared OpenGL contexts here (c.f. git history of this file), but according to
+        /// various sources on the internet, sharing OpenGL contexts does not help performance.
+        /// https://discourse.libsdl.org/t/feasibility-correctness-of-calling-gl-in-another-thread/20292/6
+        SDL_GLContext gl_context;
 
-        SDLWindowAndGLContexts()
+        SDLWindowAndGLContext()
         {
             static const int initialized = SDL_Init(SDL_INIT_VIDEO);
             if (initialized < 0) {
@@ -36,15 +34,9 @@ namespace
 
 #ifdef GOSU_IS_MAC
             if (![NSThread isMainThread]) {
-                throw std::logic_error(
-                    "First use of Gosu::Window or OpenGL must happen the main thread");
+                throw std::logic_error("Gosu::Window/OpenGL must be initialized on main thread");
             }
 #endif
-            // Except for Apple systems, which insist on having the UI on the main (first) thread,
-            // we assume that whatever thread calls this first is the main rendering thread.
-            main_thread = std::this_thread::get_id();
-
-            SDL_GL_SetAttribute(SDL_GL_SHARE_WITH_CURRENT_CONTEXT, 1);
 #ifdef GOSU_IS_OPENGLES
             // We want to use OpenGL ES 1.1, which does not yet require us to use shaders.
             SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 1);
@@ -58,60 +50,67 @@ namespace
                 throw_sdl_error("Could not create SDL window");
             }
 
-            background_threads_context = SDL_GL_CreateContext(window);
-            if (!background_threads_context) {
-                SDL_DestroyWindow(window);
-                throw_sdl_error("Could not create background OpenGL context");
-            }
-
-            main_thread_context = SDL_GL_CreateContext(window);
-            if (!main_thread_context) {
-                // Probably better to unset the current context before deleting it.
-                // Hard to make convert this to RAII without lots of lines.
-                SDL_GL_MakeCurrent(nullptr, nullptr);
-                SDL_GL_DeleteContext(background_threads_context);
+            gl_context = SDL_GL_CreateContext(window);
+            if (!gl_context) {
                 SDL_DestroyWindow(window);
                 throw_sdl_error("Could not create main OpenGL context");
             }
         }
 
-        static SDLWindowAndGLContexts& instance()
+        static SDLWindowAndGLContext& instance()
         {
-            static SDLWindowAndGLContexts instance;
+            static SDLWindowAndGLContext instance;
             return instance;
         }
     };
+
+    /// The current nesting level of OpenGLContext objects.
+    thread_local int current_nesting_depth = 0; // NOLINT(*-avoid-non-const-global-variables)
 }
 
-Gosu::OpenGLContext::OpenGLContext()
+Gosu::OpenGLContext::OpenGLContext(bool for_rendering_to_window)
 {
-    static const auto& window = SDLWindowAndGLContexts::instance();
+    static const auto& window = SDLWindowAndGLContext::instance();
 
-    if (std::this_thread::get_id() == window.main_thread) {
-        if (SDL_GL_MakeCurrent(shared_sdl_window(), window.main_thread_context) != 0) {
-            throw_sdl_error("Could not set current GL context on UI thread");
-        }
-        // No need to lock anything.
+    // All threads use a single mutex to coordinate access to their OpenGL context.
+    static std::mutex mutex;
+    if (current_nesting_depth == 0) {
+        // ...but only the innermost OpenGLContext in a thread owns the lock.
+        m_lock = std::unique_lock(mutex);
     }
-    else {
-        // All non-UI threads use a single mutex to coordinate access to their OpenGL
-        // context.
-        static std::recursive_mutex other_threads_mutex;
-        m_lock = std::unique_lock(other_threads_mutex);
-        // Making a GL context current on a background thread, but with a window, causes a
-        // deadlock on macOS because SDL tries to use dispatch_sync onto the main thread.
-        // -> Try without a window first (for macOS), then with a window (for other
-        // platforms).
-        if (SDL_GL_MakeCurrent(nullptr, window.background_threads_context) != 0
-            && SDL_GL_MakeCurrent(window.window, window.background_threads_context) != 0) {
-            throw_sdl_error("Could not set current GL context on background thread");
+
+    // Explicitly make the context current every time for_rendering_to_window is set, so that we set
+    // the current SDL_Window even if we are somehow nested into something else.
+    if (for_rendering_to_window) {
+        if (SDL_GL_MakeCurrent(window.window, window.gl_context) != 0) {
+            throw_sdl_error("Could not set current GL context for rendering to the window");
         }
+    }
+    else if (current_nesting_depth == 0) {
+        // Making a GL context current on a background thread, but with a window, causes a deadlock
+        // on macOS because SDL tries to use dispatch_sync onto the main thread.
+        // -> Try without a window first (for macOS), then with a window (for other platforms).
+        if (SDL_GL_MakeCurrent(nullptr, window.gl_context) != 0
+            && SDL_GL_MakeCurrent(window.window, window.gl_context) != 0) {
+            throw_sdl_error("Could not set current GL context");
+        }
+    }
+
+    ++current_nesting_depth;
+}
+
+Gosu::OpenGLContext::~OpenGLContext()
+{
+    --current_nesting_depth;
+
+    if (m_lock) {
+        SDL_GL_MakeCurrent(nullptr, nullptr);
     }
 }
 
 SDL_Window* Gosu::OpenGLContext::shared_sdl_window()
 {
-    static const auto& window = SDLWindowAndGLContexts::instance();
+    static const auto& window = SDLWindowAndGLContext::instance();
     return window.window;
 }
 

--- a/src/OpenGLContext.hpp
+++ b/src/OpenGLContext.hpp
@@ -16,16 +16,17 @@
 
 namespace Gosu
 {
-    /// Scoped lock/RAII class that makes an OpenGL context the current context, and prevents other
-    /// threads from taking over the context until this instance is destroyed.
+    /// Recursive lock/RAII class that makes an OpenGL context the current context, and prevents
+    /// other threads from taking over the context until this instance is destroyed.
     class OpenGLContext : Noncopyable
     {
-        std::unique_lock<std::recursive_mutex> m_lock;
+        std::unique_lock<std::mutex> m_lock;
 
     public:
         /// Makes an OpenGL context current. The very first call of this constructor may throw, all
         /// other calls can only block.
-        OpenGLContext();
+        explicit OpenGLContext(bool for_rendering_to_window = false);
+        ~OpenGLContext();
 
 #ifndef GOSU_IS_IPHONE
         // SDL does not allow creation of OpenGL contexts without creating an SDL_Window first.

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -49,10 +49,13 @@ Gosu::Texture::Texture(int width, int height, bool retro)
 
 Gosu::Texture::~Texture()
 {
-    // Only the first construction of OpenGLContext can throw, but if we get here, then we must have
-    // already created a context in the constructor. Therefore, this destructor cannot throw.
-    const OpenGLContext current_context;
-    glDeleteTextures(1, &m_tex_name);
+    try {
+        const OpenGLContext current_context;
+        glDeleteTextures(1, &m_tex_name);
+    } catch (...)
+    {
+        // Leaking is better than throwing in a destructor.
+    }
 }
 
 std::unique_ptr<Gosu::TexChunk> Gosu::Texture::try_alloc(const Bitmap& bitmap, int padding)

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -253,7 +253,7 @@ bool Gosu::Window::tick()
         SDL_EventState(SDL_DROPFILE, SDL_ENABLE);
 
         // Enable vsync.
-        const OpenGLContext current_context;
+        const OpenGLContext current_context(true);
         SDL_GL_SetSwapInterval(1);
 
         // SDL_GL_GetDrawableSize returns different values before and after showing the window.
@@ -320,7 +320,7 @@ bool Gosu::Window::tick()
     SDL_ShowCursor(needs_cursor());
 
     if (needs_redraw()) {
-        const OpenGLContext current_context;
+        const OpenGLContext current_context(true);
         viewport().frame([&] {
             draw();
             register_frame();

--- a/test/DrawableTests.cpp
+++ b/test/DrawableTests.cpp
@@ -149,8 +149,7 @@ TEST_F(DrawableTests, multithreaded_stress_test)
         thread.join();
     }
 
-    // Verify at least one of the drawables created by the other threads. If we cannot see that it
-    // is red, then texture sharing didn't work.
+    // Verify at least one of the drawables created by the other threads.
     for (const auto& drawable : drawables) {
         if (drawable->width() > 0 && drawable->height() > 0) {
             ASSERT_EQ(drawable->to_bitmap().pixel(0, 0), Gosu::Color::RED);


### PR DESCRIPTION
The previous handling had several problems:
* The current context was never unset. This prevented other threads from making the shared context current when using Nvidia drivers under Linux.
* Sharing resources across multiple contexts seems to be pointless, at least from internet hearsay. I didn't notice a difference locally.
* Texture::~Texture() could actually throw, contrary to what its outdated comment said.