### PR TITLE
Initial stab at Swift support

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.22.1)
 
+add_subdirectory(Swift)
 add_subdirectory(TextInput)
 add_subdirectory(Tutorial)

--- a/examples/Swift/CMakeLists.txt
+++ b/examples/Swift/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.22.1)
+
+project(SwiftExample LANGUAGES Swift CXX)
+
+add_executable(SwiftExample
+        Test.swift)
+
+# Gosu's own examples have to be built into the parent directory so that they
+# can find the shared 'media' directory.
+# You do not have to do this in your own Gosu projects.
+get_filename_component(PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} PATH CACHE)
+set_target_properties(SwiftExample PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PARENT_DIR})
+
+if (NOT TARGET Gosu::Gosu)
+    find_package(Gosu REQUIRED)
+endif ()
+target_link_libraries(SwiftExample Gosu::Gosu)
+# Enable Cxx interoperability
+target_compile_options(SwiftExample PUBLIC
+  "SHELL:-Xcc -std=c++20"
+  "-cxx-interoperability-mode=default")

--- a/examples/Swift/Test.swift
+++ b/examples/Swift/Test.swift
@@ -1,0 +1,23 @@
+import Gosu
+
+print("Hello, Gosu! \(Gosu.VERSION)")
+
+let random = Gosu.random(0, 100)
+print("Random: \(random)")
+
+let color = Gosu.Color(0, 0, 0)
+print("Color: \(color.red), \(color.green), \(color.blue), \(color.alpha)")
+
+let bitmap = Gosu.Bitmap(100, 100, Gosu.Color.RED)
+print("Bitmap: \(bitmap.width()), \(bitmap.height())")
+
+let image = Gosu.Image("media/Starfighter.bmp", 0)
+print("Image: \(image.width()), \(image.height())")
+
+let sample = Gosu.Sample("media/Beep.wav")
+sample.play(1, 1, false)
+
+// TODO: Implement support for the Window class
+//var window = Gosu.Window(640, 480, 0, 16.666666)
+
+Gosu.sleep(500)

--- a/include/Gosu/module.modulemap
+++ b/include/Gosu/module.modulemap
@@ -1,0 +1,5 @@
+module Gosu {
+  requires cplusplus
+  umbrella header "Gosu.hpp"
+  export *
+}

--- a/include/Gosu/module.modulemap
+++ b/include/Gosu/module.modulemap
@@ -1,5 +1,6 @@
 module Gosu {
   requires cplusplus
   umbrella header "Gosu.hpp"
+  link "gosu"
   export *
 }


### PR DESCRIPTION
Hey Gosu team!

I've been playing around a bit with Swift and Gosu, and was wondering if this is something that would be worth pursuing.

The basic structs can be imported no problem and can be used directly in Swift.

What currently does not "just work" is the `Window` class for example as it's using reference symantics and would need marking as such in Swift (or using a C bridge, like the one in FFI).

Please let me know your thoughts and feel free to close this if this is definitely a do-not-want. Thanks!